### PR TITLE
Removed SystemDrive and Used TEMP dir instead

### DIFF
--- a/shares/setup/analyzer.py
+++ b/shares/setup/analyzer.py
@@ -192,7 +192,7 @@ def install_target(share_path, target_name):
     log = logging.getLogger("Core.InstallTarget")
 
     target_src = os.path.join(share_path, target_name)
-    target_dst = "%s\\" % os.getenv("SystemDrive")
+    target_dst = "%s\\" % os.getenv("TEMP")
 
     if not os.path.exists(target_src):
         log.critical("Cannot find target file at path \"%s\"." % target_src)
@@ -208,7 +208,7 @@ def install_target(share_path, target_name):
                      "\"%s\": %s." % (target_src, target_dst, why))
         return False
 
-    return "%s\\%s" % (os.getenv("SystemDrive"), target_name)
+    return "%s\\%s" % (os.getenv("TEMP"), target_name)
 
 def add_file_to_list(file_path):
     """

--- a/shares/setup/lib/cuckoo/paths.py
+++ b/shares/setup/lib/cuckoo/paths.py
@@ -23,7 +23,7 @@ CUCKOO_SETUP_SHARE = "\\\\VBOXSVR\\setup\\"
 SYSTEM_SETUP_SRC = os.path.join(CUCKOO_SETUP_SHARE, "system\\")
 CUCKOO_SETUP_SRC = os.path.join(CUCKOO_SETUP_SHARE, "cuckoo\\")
 
-CUCKOO_PATH = "%s\\cuckoo\\" % os.getenv("SystemDrive")
+CUCKOO_PATH = "%s\\cuckoo\\" % os.getenv("TEMP")
 CUCKOO_DLL_FOLDER = os.path.join(CUCKOO_PATH, "dll")
 CUCKOO_DLL_PATH = os.path.join(CUCKOO_PATH, "dll\\cmonitor.dll")
 


### PR DESCRIPTION
I did remove the dependency from SystemDrive as target. It breaks in Windows 7 and normally a normal user won't have access to write on SystemDrive. Instead I used %TEMP% a default variable as well

Maybe we should make it configurable. something to think about 
