### PR TITLE
Memdump

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -33,3 +33,9 @@ tcpdump = /usr/sbin/tcpdump
 # Specify the network interface name on which tcpdump should monitor the
 # traffic. Make sure the interface is active.
 interface = vboxnet0
+
+# Do a full memory dump of the VM _brefore_ the sample runs. This dump can be analysed with volatility
+do_predump = no
+
+# Do a full memory dump of the VM _after_ the sample ran. This dump can be analysed with volatility
+do_postdump = no

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -118,6 +118,14 @@ class MachineManager(object):
         """
         raise NotImplementedError
 
+	def memdump(self, label, filename):
+		"""Dump the memory of the whole machine
+		@param label: machine name.
+		@param filename: target filename.
+		@raise NotImplementedError: this method is abstract.
+		"""
+		raise NotImplementedError
+
     def _list(self):
         """Lists virtual machines configured.
         @raise NotImplementedError: this method is abstract.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -122,10 +122,16 @@ class AnalysisManager(Thread):
             mmanager.start(vm.label)
             # Initialize guest manager
             guest = GuestManager(vm.ip, vm.platform)
+            # Pre memdump
+            if self.cfg.cuckoo.do_predump:
+                mmanager.memdump(vm.label, os.path.join(self.analysis.results_folder,"pre.memdump"))
             # Launch analysis
             guest.start_analysis(options)
             # Wait for analysis to complete
             success = guest.wait_for_completion()
+            # Post memdump
+            if self.cfg.cuckoo.do_postdump:
+                mmanager.memdump(vm.label, os.path.join(self.analysis.results_folder,"post.memdump"))
             # Stop sniffer
             if sniffer:
                 sniffer.stop()

--- a/modules/machinemanagers/virtualbox.py
+++ b/modules/machinemanagers/virtualbox.py
@@ -61,6 +61,20 @@ class VirtualBox(MachineManager):
         except OSError:
             raise CuckooMachineError("VBoxManage OS error restoring vm's snapshot or file not found")
 
+    def memdump(self, label, filename):
+        """Dump the memory of the whole machine
+		@param label: machine name.
+		@param filename: target filename.
+		@raise NotImplementedError: this method is abstract.
+		"""
+        try:
+            if subprocess.call(["VBoxManage", "debugvm", label, "dumpguestcore", "--filename", filename],
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE):
+                raise CuckooMachineError("VBoxManage exited with error memdumping vm")
+        except OSError:
+            raise CuckooMachineError("VBoxManage OS error memdumping vm or file not found")
+
     def _list(self):
         """Lists virtual machines installed.
         @return: virtual machine names list.


### PR DESCRIPTION
Adds a virtual box memdump feature. Full system memdumps can be triggered before malware is injected or after it ran.

Volatility is able to open the memdumps and can be used to find traces of rootkits (1)

Not included:
- Volatility does not yet produces json logfiles
- There is no processing for this data
- Reports are not generated

This will be fixed with the next commits.

1: Volatility needs a special virtualbox plugin
