### PR TITLE
Found another log bug.

### DIFF
--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -76,7 +76,7 @@ def init_logging():
     sh = logging.StreamHandler()
     sh.setFormatter(formatter)
     log.addHandler(sh)
-    fh = logging.FileHandler(os.path.join("log", "cuckoo.log"))
+    fh = logging.FileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))
     fh.setFormatter(formatter)
     log.addHandler(fh)
     log.setLevel(logging.INFO)


### PR DESCRIPTION
I found another case where CUCKOO_ROOT was not used to build the correct path in lib/cuckoo/core/startup.py
