### PR TITLE
Fixed missing RegCreateKeyEx keys

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -218,7 +218,7 @@ class Summary:
             handles = []
 
             for call in process["calls"]:
-                if call["api"].startswith("RegOpenKeyEx"):
+                if (call["api"].startswith("RegOpenKeyEx")) or (call["api"].startswith("RegCreateKeyEx")):
                     registry = 0
                     subkey = ""
                     handle = 0


### PR DESCRIPTION
RegCreateKeyEx is also able to open registry keys. These keys were missing from the summary
