### PR TITLE
Decode the file paths with the codec 'mbcs'.

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -40,6 +40,7 @@ def add_file(file_path):
 
     if os.path.exists(file_path):
         if file_path not in FILES_LIST:
+            file_path = file_path.decode("mbcs")
             log.info("Added new file to list with path: %s" % file_path)
             FILES_LIST.append(file_path)
 


### PR DESCRIPTION
mbcs is the default encoding used by windows. If the default language of
the system is not english and you have a non-ascii character in a path,
the module "JsonDump" will fail at runtime.

My system is in French (don't ask... :) ) and analysis.log contains entries like: 

INFO: Dropped file "C:\Documents and Settings\raphael\Menu D<E9>marrer\Programmes....

My pull request will fix that problem by decoding the path in utf-8.

But I'm not sure it fixes the problem properly: I should probably use the agent to pass to the host the encoding used by the guest (see http://docs.python.org/library/sys.html#sys.getfilesystemencoding).
But windows always use mbcs...

What do you think ?
