### PR TITLE
A list for families known to trigger a specific signature added

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -201,6 +201,7 @@ class Signature(object):
     enabled = True
     minimum = None
     maximum = None
+    families = []
 
     def __init__(self):
         self.data = []


### PR DESCRIPTION
this one adds a list to store the families known to trigger a specific signature. This way it could be possible to guess the family of a sample (having enough signatures supporting this feature)
