### PR TITLE
Using WatchedFileHandler for logging allows usage of logrotate

### DIFF
--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -8,6 +8,7 @@ import json
 import urllib
 import urllib2
 import logging
+import logging.handlers
 
 from lib.cuckoo.common.constants import CUCKOO_ROOT, CUCKOO_VERSION
 from lib.cuckoo.common.exceptions import CuckooStartupError
@@ -87,7 +88,7 @@ def init_logging():
     sh = logging.StreamHandler()
     sh.setFormatter(formatter)
     log.addHandler(sh)
-    fh = logging.FileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))
+    fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))
     fh.setFormatter(formatter)
     log.addHandler(fh)
     log.setLevel(logging.INFO)


### PR DESCRIPTION
Minor change to the initialization of logging to allow for logrotate to rotate logs without breaking them. With the normal FileHandler, when logrotate acts, the handler gets broken and cuckoo stops logging.
