### PR TITLE
Prevent error when the attribute is not available (eg while waiting for the socket) on Python 2.6

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -104,7 +104,7 @@ class TimeoutServer(xmlrpclib.ServerProxy):
         t = self._ServerProxy__transport
         t.timeout = timeout
         # if we still have a socket we need to update that as well
-        if t._connection[1] and t._connection[1].sock:
+        if hasattr(t, '_connection') and t._connection[1] and t._connection[1].sock:
             t._connection[1].sock.settimeout(timeout)
 
 class TimeoutTransport(xmlrpclib.Transport):


### PR DESCRIPTION
Installed the new cuckoo 0.5 on an Ubuntu 10.04.4 LTS with python 2.6 and every attempt to analyse a sample or a url ended before starting (see debug log excerpt below).

By checking if the attribute is available before checking it, seemed to have solved the problem and analysis work again.

I did a new test today and this doesn't seem to be an issue on Python 2.7.2.

<pre>
2012-12-27 13:11:47,807 [modules.machinemanagers.virtualbox] DEBUG: Starting vm Win_XP_Pro_32
2012-12-27 13:11:47,808 [modules.machinemanagers.virtualbox] DEBUG: Getting status for Win_XP_Pro_32
2012-12-27 13:11:48,349 [modules.machinemanagers.virtualbox] DEBUG: Machine Win_XP_Pro_32 status saved
2012-12-27 13:11:49,535 [modules.machinemanagers.virtualbox] DEBUG: Getting status for Win_XP_Pro_32
2012-12-27 13:11:50,089 [modules.machinemanagers.virtualbox] DEBUG: Machine Win_XP_Pro_32 status saved
2012-12-27 13:11:53,358 [modules.machinemanagers.virtualbox] DEBUG: Getting status for Win_XP_Pro_32
2012-12-27 13:11:53,525 [modules.machinemanagers.virtualbox] DEBUG: Machine Win_XP_Pro_32 status running
2012-12-27 13:11:53,645 [lib.cuckoo.core.guest] INFO: Starting analysis on guest (id=cuckoo1, ip=192.168.1.39)
2012-12-27 13:11:53,645 [lib.cuckoo.core.guest] DEBUG: cuckoo1: waiting for status 0x0001
2012-12-27 13:11:53,646 [modules.machinemanagers.virtualbox] DEBUG: Stopping vm Win_XP_Pro_32
2012-12-27 13:11:53,646 [modules.machinemanagers.virtualbox] DEBUG: Getting status for Win_XP_Pro_32
2012-12-27 13:11:53,742 [modules.machinemanagers.virtualbox] DEBUG: Machine Win_XP_Pro_32 status running
2012-12-27 13:11:54,925 [modules.machinemanagers.virtualbox] DEBUG: Getting status for Win_XP_Pro_32
2012-12-27 13:11:55,495 [modules.machinemanagers.virtualbox] DEBUG: Machine Win_XP_Pro_32 status poweroff
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/home/cuckoo/cuckoo-0.5/lib/cuckoo/core/scheduler.py", line 318, in run
    success = self.launch_analysis()
  File "/home/cuckoo/cuckoo-0.5/lib/cuckoo/core/scheduler.py", line 240, in launch_analysis
    guest.start_analysis(options)
  File "/home/cuckoo/cuckoo-0.5/lib/cuckoo/core/guest.py", line 136, in start_analysis
    self.wait(CUCKOO_GUEST_INIT)
  File "/home/cuckoo/cuckoo-0.5/lib/cuckoo/core/guest.py", line 59, in wait
    self.server._set_timeout(self.timeout)
  File "/home/cuckoo/cuckoo-0.5/lib/cuckoo/common/utils.py", line 107, in _set_timeout
    if t._connection and t._connection[1] and t._connection[1].sock:
AttributeError: TimeoutTransport instance has no attribute '_connection'
<pre>
## 

lorenzo
