### PR TITLE
Check for Word Viewer if Word not found

### DIFF
--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -17,7 +17,9 @@ class DOC(Package):
             os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office11", "WINWORD.EXE"),
             os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office12", "WINWORD.EXE"),
             os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office14", "WINWORD.EXE"),
-            os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office15", "WINWORD.EXE")
+            os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office15", "WINWORD.EXE"),
+            os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "WORDVIEW.EXE"),
+            os.path.join(os.getenv("ProgramFiles"), "Microsoft Office", "Office11", "WORDVIEW.EXE")
         ]
 
         for path in paths:


### PR DESCRIPTION
For people who don't want to pay for Office license or pirate it, Word Viewer is vulnerable to some of the same exploits that Word is, and it's free. Can be used for example to open RTF files.

http://www.microsoft.com/en-us/download/details.aspx?id=4

This version goes in the Office11 directory. Not sure if there are later versions, or what path earlier versions are installed in.
