### PR TITLE
Package for analysis of .cpl files

### DIFF
--- a/analyzer/windows/modules/packages/cpl.py
+++ b/analyzer/windows/modules/packages/cpl.py
@@ -16,10 +16,10 @@ class Cpl(Package):
 
         # file need the .cpl extention to execute
         if path.endswith('.cpl'):
-                cplpath = path
+            cplpath = path
         else:
-                cplpath = "%s.cpl" % path
-                os.rename(path, cplpath)
+            cplpath = "%s.cpl" % path
+            os.rename(path, cplpath)
 
 
         if function:


### PR DESCRIPTION
This is a pull request to add a package to analysis of .cpl files (Control Panel addons). 
Brazillian gangs are using cpl files as droppers, although these are DLLs in it's essence, you need to call the rundll32  with shell32.dll,Control_RunDLL before the arguments of the .cpl file. The regular dll package will not run these kind of files sucessfull.

This package implements this.

Thanks.
