### PR TITLE
Fix view file API call.

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -750,14 +750,17 @@ class Database(object):
             return False
         return True
 
-    def view_sample(self, sample_id):
-        """Retrieve information on a sample.
-        @param sample_id: ID of the sample to query.
-        @return: details on the sample.
+    def view_sample(self, task_id):
+        """Retrieve information on a sample given a task id.
+        @param task_id: ID of the task to query.
+        @return: details on the sample used in task: task_id.
         """
         session = self.Session()
         try:
+            sample_id = session.query(Task).get(task_id).sample_id
             sample = session.query(Sample).get(sample_id)
+        except AttributeError:
+            return None
         except SQLAlchemyError:
             return None
         return sample

--- a/utils/api.py
+++ b/utils/api.py
@@ -203,9 +203,9 @@ def files_view(md5=None, sha256=None, sample_id=None):
     response = {}
 
     if md5:
-        sample = db.find_sample(md5=md5)[0]
+        sample = db.find_sample(md5=md5)
     elif sha256:
-        sample = db.find_sample(sha256=sha256)[0]
+        sample = db.find_sample(sha256=sha256)
     elif sample_id:
         sample = db.view_sample(sample_id)
     else:


### PR DESCRIPTION
File detail lookups via MD5 and SHA256 failed due to improperly
calling [0] on a sample object. File detail lookups via task ID
failed when task ID involved a sample previously submitted. Both
now work as intended.
