### PR TITLE
db.find_sample() already returns a single object

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -203,9 +203,9 @@ def files_view(md5=None, sha256=None, sample_id=None):
     response = {}
 
     if md5:
-        sample = db.find_sample(md5=md5)[0]
+        sample = db.find_sample(md5=md5)
     elif sha256:
-        sample = db.find_sample(sha256=sha256)[0]
+        sample = db.find_sample(sha256=sha256)
     elif sample_id:
         sample = db.view_sample(sample_id)
     else:


### PR DESCRIPTION
Hi,

Starting the REST api and trying to use it gives an error in files_view when searching for a SHA256 hash:

```
> utils/api.py
Bottle server starting up (using WSGIRefServer())...
Listening on http://localhost:8090/
Hit Ctrl-C to quit.
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/bottle.py", line 737, in _handle
    return route.call(**args)
  File "/usr/lib/python2.7/site-packages/bottle.py", line 1506, in wrapper
    rv = callback(*a, **ka)
  File "/usr/lib/python2.7/site-packages/bottle.py", line 1456, in wrapper
    rv = callback(*a, **ka)
  File "utils/api.py", line 189, in files_view
    sample = db.find_sample(sha256=sha256)[0]
TypeError: 'Sample' object does not support indexing
```

(line numbers here are from the "master" branch as it seems)

The commit I've tried to make here fixed it for me, so this github stuff works out, feel free...

Cheers,
  Thiemo
