### PR TITLE
Fixed issue with submitted files that are all numbers

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -377,7 +377,7 @@ class Analyzer:
         # we store the path.
         if self.config.category == "file":
             self.target = os.path.join(os.environ["TEMP"] + os.sep,
-                                       self.config.file_name)
+                                       str(self.config.file_name))
         # If it's a URL, well.. we store the URL.
         else:
             self.target = self.config.target


### PR DESCRIPTION
Fixed issue with submitted files that are all numbers in the analyzer package for the Windows platform.  This bug can be easily replicated by uploading a file with the name being all numbers with no extensions ex. "12345".
