### PR TITLE
Added: tcpdump flag to run as cuckoo user

### DIFF
--- a/lib/cuckoo/core/sniffer.py
+++ b/lib/cuckoo/core/sniffer.py
@@ -46,6 +46,7 @@ class Sniffer:
             return False
 
         pargs = [self.tcpdump, "-U", "-q", "-i", interface, "-n"]
+        pargs.extend(["-Z", "cuckoo"])
         pargs.extend(["-w", file_path])
         pargs.extend(["host", host])
         # Do not capture XMLRPC agent traffic.


### PR DESCRIPTION
Current setting causes pcaps to be created as user root, this change allows pcaps to be saved as cuckoo, as is the rest of the report. May be possible to dynamically pull current user instead?
