### PR TITLE
Adding pagination to web.py and api.py

### DIFF
--- a/data/html/base-web.html
+++ b/data/html/base-web.html
@@ -72,7 +72,7 @@ body {
                 <div class="nav-collapse">
                     <ul class="nav">
                         <li><a href="/">Home</a></li>
-                        <li><a href="/browse">Browse</a></li>
+                        <li><a href="/browse-page/1">Browse</a></li>
                     </ul>
                 </div>
             </div>

--- a/data/html/browse-page.html
+++ b/data/html/browse-page.html
@@ -1,0 +1,46 @@
+{% extends "base-web.html" %}
+{% block content %}
+    <div class="tasks">
+        <div class="page-header">
+            <h3>Analysis Tasks <small>performed, processing and pending analyses</small></h3>
+        </div>
+        {% include "pagination-menu.html" %}
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Category</th>
+                    <th style="width: 40%;">Target</th>
+                    <th>Added</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for row in rows %}
+                <tr>
+                    <td>{{row.id}}</td>
+                    <td>{{row.category|upper}}</td>
+                    <td>
+                        {% if row.processed %}
+                            <a href="/view/{{row.id}}">
+                        {% endif %}
+                        <span class="mono">
+                            {% if row.category == "file" %}
+                                {{row.md5}}
+                            {% elif row.category == "url" %}
+                                {{row.target}}
+                            {% endif %}
+                        </span>
+                        {% if row.processed %}
+                            </a>
+                        {% endif %}
+                    </td>
+                    <td>{{row.added_on}}</td>
+                    <td>{{row.status}}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% include "pagination-menu.html" %}
+    </div>
+{% endblock %}

--- a/data/html/pagination-menu.html
+++ b/data/html/pagination-menu.html
@@ -1,0 +1,78 @@
+        <table style="width: 100%; margin-bottom: 18px;">
+            <tbody>
+                <tr>
+                    <td style="text-align: left; width: 20%;">
+                        Results {{ pagination.start }}-{{ pagination.end }} of {{ pagination.tot_results }}
+                    </td>
+                    <td style="text-align: left; width: 20%;">
+                        Results per page:
+                        <a href="/browse-page/{{ pagination.page_id }}/25">25</a>
+                        <a href="/browse-page/{{ pagination.page_id }}/50">50</a>
+                        <a href="/browse-page/{{ pagination.page_id }}/100">100</a>
+                        <a href="/browse-page/{{ pagination.page_id }}/200">200</a>
+                    </td>
+                    <td style="text-align: center; width: 20%;">
+                    Page {{ pagination.page_id }} of {{ pagination.tot_pages }}
+                    </td>
+                    <td style="text-align: right; width: 40%;">
+                    {% if pagination.page_id > 1 %}
+                        <a href="/browse-page/1">&lt;&lt;</a>&nbsp;
+                        <a href="/browse-page/{{ pagination.page_id - 1 }}">&lt;</a>
+                    {% else %}
+                        &lt;&lt;&nbsp;
+                        &lt;
+                    {% endif %}
+                        &nbsp;
+                    {% if pagination.page_id > 5 %}
+                        <a href="/browse-page/{{ pagination.page_id - 5 }}">{{ pagination.page_id - 5 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.page_id > 4 %}
+                        <a href="/browse-page/{{ pagination.page_id - 4 }}">{{ pagination.page_id - 4 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.page_id > 3 %}
+                        <a href="/browse-page/{{ pagination.page_id - 3 }}">{{ pagination.page_id - 3 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.page_id > 2 %}
+                        <a href="/browse-page/{{ pagination.page_id - 2 }}">{{ pagination.page_id - 2 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.page_id > 1 %}
+                        <a href="/browse-page/{{ pagination.page_id - 1 }}">{{ pagination.page_id - 1 }}</a>
+                        &nbsp;
+                    {% endif %}
+                        {{ pagination.page_id }}
+                        &nbsp;
+                    {% if pagination.tot_pages - pagination.page_id > 0 %}
+                        <a href="/browse-page/{{ pagination.page_id + 1 }}">{{ pagination.page_id + 1 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.tot_pages - pagination.page_id > 1 %}
+                        <a href="/browse-page/{{ pagination.page_id + 2 }}">{{ pagination.page_id + 2 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.tot_pages - pagination.page_id > 2 %}
+                        <a href="/browse-page/{{ pagination.page_id + 3 }}">{{ pagination.page_id + 3 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.tot_pages - pagination.page_id > 3 %}
+                        <a href="/browse-page/{{ pagination.page_id + 4 }}">{{ pagination.page_id + 4 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.tot_pages - pagination.page_id > 4 %}
+                        <a href="/browse-page/{{ pagination.page_id + 5 }}">{{ pagination.page_id + 5 }}</a>
+                        &nbsp;
+                    {% endif %}
+                    {% if pagination.page_id < pagination.tot_pages %}
+                        <a href="/browse-page/{{ pagination.page_id + 1 }}">&gt;</a>&nbsp;
+                        <a href="/browse-page/{{ pagination.tot_pages }}">&gt;&gt;</a>
+                    {% else %}
+                        &gt;&nbsp;
+                        &gt;&gt;
+                    {% endif %}
+                    </td>
+                </tr>
+            </tbody>
+        </table>

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -757,7 +757,7 @@ class Database(object):
                         memory,
                         enforce_timeout)
 
-    def list_tasks(self, limit=None, details=False):
+    def list_tasks(self, limit=None, details=False, offset=None):
         """Retrieve list of task.
         @param limit: specify a limit of entries.
         @return: list of tasks.
@@ -765,14 +765,31 @@ class Database(object):
         session = self.Session()
         try:
             if details:
-                tasks = session.query(Task).options(joinedload("guest"), joinedload("errors")).order_by("added_on desc").limit(limit).all()
+                tasks = session.query(Task).options(joinedload("guest"), joinedload("errors")).order_by("added_on desc").limit(limit).offset(offset).all()
             else:
-                tasks = session.query(Task).order_by("added_on desc").limit(limit).all()
+                tasks = session.query(Task).order_by("added_on desc").limit(limit).offset(offset).all()
         except SQLAlchemyError:
             return None
         finally:
             session.close()
         return tasks
+
+    def count_tasks(self, status=None):
+        """Count tasks in the database
+        @param status: apply a filter according to the task status
+        @return: number of tasks found
+        """
+        session = self.Session()
+        try:
+            if status:
+                tasks_count = session.query(Task).filter(Task.status == status).count()
+            else:
+                tasks_count = session.query(Task).count()
+        except SQLAlchemyError:
+            return 0
+        finally:
+            session.close()
+        return tasks_count
 
     def view_task(self, task_id, details=False):
         """Retrieve information on a task.

--- a/utils/api.py
+++ b/utils/api.py
@@ -109,13 +109,14 @@ def tasks_create_url():
     return jsonize(response)
 
 @route("/tasks/list", method="GET")
-@route("/tasks/list/<limit>", method="GET")
-def tasks_list(limit=None):
+@route("/tasks/list/<limit:int>", method="GET")
+@route("/tasks/list/<limit:int>/<offset:int>", method="GET")
+def tasks_list(limit=None, offset=None):
     response = {}
 
     response["tasks"] = []
 
-    for row in db.list_tasks(limit, details=True):
+    for row in db.list_tasks(limit=limit, details=True, offset=offset):
         task = row.to_dict()
         task["guest"] = {}
         if row.guest:

--- a/utils/web.py
+++ b/utils/web.py
@@ -7,6 +7,9 @@ import os
 import sys
 import logging
 import argparse
+from datetime import datetime, timedelta
+import time
+
 try:
     from jinja2.loaders import FileSystemLoader
     from jinja2.environment import Environment
@@ -32,6 +35,60 @@ env.loader = FileSystemLoader(os.path.join(CUCKOO_ROOT, "data", "html"))
 # Global db pointer.
 db = Database()
 
+
+def parse_tasks(rows):
+    """Parse tasks from DB and prepare them to be shown in the output table"""
+    tasks = []
+    for row in rows:
+        task = {
+            "id" : row.id,
+            "target" : row.target,
+            "category" : row.category,
+            "status" : row.status,
+            "added_on" : row.added_on,
+            "processed" : False
+        }
+
+        if os.path.exists(os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task["id"]), "reports", "report.html")):
+            task["processed"] = True
+
+        if row.category == "file":
+            sample = db.view_sample(row.id)
+            task["md5"] = sample.md5
+
+        tasks.append(task)
+    return tasks
+
+def get_pagination_limit(new_limit):
+    """Defines the right pagination limit and sets cookies accordingly."""
+    default_limit = 50
+    
+    limit_cookie = request.get_cookie("pagination_limit")
+    logging.info("Got cookie: {0}".format(limit_cookie))
+    
+    cookie_expires = time.mktime((datetime.now() + timedelta(days=365)).timetuple())
+    
+    if new_limit <= 0:
+        if limit_cookie:
+            try:
+                limit = int(limit_cookie)
+                logging.info("Using limit from cookie: {0}".format(limit))
+                #response.set_header('Set-Cookie', 'pagination_limit={0}'.format(limit))
+                response.set_cookie('pagination_limit', str(limit), path='/', expires=cookie_expires)
+            except Exception as e:
+                logging.error("Cookie: {0}, exception: {1}".format(limit_cookie, e))
+                limit = default_limit
+        else:
+            limit = default_limit
+            logging.info("Using default limit: {0}".format(limit))
+    else:
+        limit = new_limit
+        logging.info("Setting new limit: {0}".format(limit))
+        #response.set_header('Set-Cookie', 'pagination_limit={0}'.format(limit))
+        response.set_cookie('pagination_limit', str(limit), path='/', expires=cookie_expires)
+    
+    return limit
+
 @hook("after_request")
 def custom_headers():
     """Set some custom headers across all HTTP responses."""
@@ -53,29 +110,53 @@ def index():
 def browse():
     rows = db.list_tasks()
 
-    tasks = []
-    for row in rows:
-        task = {
-            "id" : row.id,
-            "target" : row.target,
-            "category" : row.category,
-            "status" : row.status,
-            "added_on" : row.added_on,
-            "processed" : False
-        }
-
-        if os.path.exists(os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task["id"]), "reports", "report.html")):
-            task["processed"] = True
-
-        if row.category == "file":
-            sample = db.view_sample(row.id)
-            task["md5"] = sample.md5
-
-        tasks.append(task)
+    tasks = parse_tasks(rows)
 
     template = env.get_template("browse.html")
 
     return template.render({"rows" : tasks, "os" : os})
+
+@route("/browse-page")
+@route("/browse-page/")
+@route("/browse-page/<page_id:int>")
+@route("/browse-page/<page_id:int>/")
+@route("/browse-page/<page_id:int>/<new_limit:int>")
+def browse_page(page_id=1, new_limit=-1):
+    if page_id < 1:
+        page_id = 1
+    
+    limit = get_pagination_limit(new_limit)
+    
+    tot_results = db.count_tasks()
+    tot_pages = (tot_results / limit) + ((tot_results % limit) and 1 or 0) # Add 1 to tot_pages
+                                                                           # if there's some remainder
+    # Check that the user doesn't require an impossible pagination
+    if page_id > tot_pages:
+        page_id = tot_pages
+    
+    offset = (page_id - 1) * limit
+    rows = db.list_tasks(limit=limit, offset=offset)
+    
+    tasks = parse_tasks(rows)
+    
+    if tot_results:
+        pagination_start = offset + 1
+    else:
+        pagination_start = 0
+    pagination_end = offset + len(rows)
+    
+    pagination = {
+        'start' : pagination_start,
+        'end' : pagination_end,
+        'limit' : limit,
+        'page_id' : page_id,
+        'tot_results' : tot_results,
+        'tot_pages' : tot_pages
+    }
+    
+    template = env.get_template("browse-page.html")
+    
+    return template.render({"rows": tasks, "os" : os, "pagination" : pagination})
 
 @route("/static/<filename:path>")
 def server_static(filename):


### PR DESCRIPTION
The modification of api.py is trivial, while in web.py I am basically adding a new route:

```
@route("/browse-page/<page_id:int>/<new_limit:int>")
```

Both parameters are optional and, while the first defaults to 1, the second is only used when you want to set a new pagination size (default value is 50 results per page). When set to a non-default value, the pagination size is stored in a cookie to be kept between different browser sessions.

Some of the code of the old route "/browse" was put into a separate function parse_tasks(), that helps making it reusable.
