### PR TITLE
Fixing bug with wrong variable name

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -252,7 +252,7 @@ class FileUpload(object):
         if dir_part:
             try: create_folder(self.storagepath, dir_part)
             except CuckooOperationalError:
-                log.error("Unable to create folder %s" % folder)
+                log.error("Unable to create folder %s" % dir_part)
                 return False
 
         file_path = os.path.join(self.storagepath, buf.strip())


### PR DESCRIPTION
Fixing wrong variable name, should be "dir_part" and not "folder".
