### PR TITLE
Avoid attempting to recreate existing dirs

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -20,7 +20,7 @@ def create_folders(root=".", folders=[]):
     @raise CuckooOperationalError: if fails to create folder.
     """
     for folder in folders:
-        if os.path.exists(os.path.join(root, folder)):
+        if os.path.isdir(os.path.join(root, folder)):
             continue
         else:
             create_folder(root, folder)
@@ -32,12 +32,13 @@ def create_folder(root=".", folder=None):
     @raise CuckooOperationalError: if fails to create folder.
     """
     if not os.path.exists(os.path.join(root, folder)) and folder:
-        try:
-            folder_path = os.path.join(root, folder)
-            os.makedirs(folder_path)
-        except OSError:
-            raise CuckooOperationalError("Unable to create folder: %s"
-                                         % folder_path)
+        folder_path = os.path.join(root, folder)
+        if not os.path.isdir(folder_path):
+            try:
+                os.makedirs(folder_path)
+            except OSError:
+                raise CuckooOperationalError("Unable to create folder: %s"
+                                            % folder_path)
 
 def delete_folder(folder):
     """Delete a folder and all its subdirectories.


### PR DESCRIPTION
In lib.cuckoo.common.utils, function create_folders() checks whether a given directory already exists before attempting to create it. To do so, it uses os.path.exists: it works, but it would be better to use os.path.isdir, as there might already be a file with the same name of the desired directory and you would end up with some errors.

At the same time, function create_folder() does not check if the directory exists before creating it. So, if you are calling it from inside create_folders(), it works pretty well as it will be create_folders() to perform the check; but if you are calling it directly (for example from inside resultserver.read_next_message()), it will fail if the directory already exists.
