### PR TITLE
Address "browse" bug

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -809,14 +809,13 @@ class Database(object):
             session.close()
         return True
 
-    def view_sample(self, task_id):
-        """Retrieve information on a sample given a task id.
-        @param task_id: ID of the task to query.
-        @return: details on the sample used in task: task_id.
+    def view_sample(self, sample_id):
+        """Retrieve information on a sample given a sample id.
+        @param sample_id: ID of the sample to query.
+        @return: details on the sample used in sample: sample_id.
         """
         session = self.Session()
         try:
-            sample_id = session.query(Task).get(task_id).sample_id
             sample = session.query(Sample).get(sample_id)
         except (SQLAlchemyError, AttributeError):
             return None


### PR DESCRIPTION
I ran into an issue with the "browse" feature of the bottle interface. Tracking it backwards, it looks like calls to Database.view_sample were giving a sample_id. When looking at the database module the Database.view_sample method expects a task_id. This issue doesn't crop up unless the system is receiving URLs and Samples for processing. When both are received, the task_id is no longer aligned with the sample_id, so calls to "view_task" are mismatched.

Looking through the code base it's only used in a couple of places, and they both pass a sample_id. It makes sense to change this method to accept a sample_id, since you can always get a sample_id from the task object, which you can get from the task_id.

-Ben

```
grep -r view_sample cuckoo
cuckoo/lib/cuckoo/core/database.py:    def view_sample(self, task_id):
cuckoo/utils/api.py:        sample = db.view_sample(sample_id)
cuckoo/utils/web.py:            sample = db.view_sample(row.sample_id)
```
