### PR TITLE
allow multiple auxiliary modules to be loaded

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -84,10 +84,10 @@ class RunAuxiliary(object):
                     options = self.cfg.get(module_name)
                 except CuckooOperationalError:
                     log.debug("Auxiliary module %s not found in configuration file", module_name)
-                    return
+                    continue
 
                 if not options.enabled:
-                    return
+                    continue
 
                 current.set_task(self.task)
                 current.set_machine(self.machine)


### PR DESCRIPTION
Don't just return after the first (un)successful run through the list of auxiliary modules
