### PR TITLE
Fixed XMLRPC timeout with python 2.6.6

### DIFF
--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -148,7 +148,9 @@ class TimeoutTransport(xmlrpclib.Transport):
 
     def make_connection(self, *args, **kwargs):
         conn = xmlrpclib.Transport.make_connection(self, *args, **kwargs)
-        if self.timeout != None: conn.timeout = self.timeout
+        if self.timeout != None: 
+            conn.timeout = self.timeout
+            conn._conn.timeout = self.timeout
         return conn
 
 # http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python


### PR DESCRIPTION
Fixes timeout over xmlrpc with python 2.6.6
See http://public.honeynet.org/pipermail/cuckoo/2013-August/001562.html for more details.
