### PR TITLE
not enough freespace error message

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -22,6 +22,12 @@ memory_dump = no
 # Each task found in status "processing" is re-queued for analysis.
 reschedule = yes
 
+# Minimum amount of free space (in MB) available before starting a new task. 
+# This tries to avoid failing an analysis because the reports can't be written 
+# due out-of-diskspace errors. Setting this value to 0 disables the check.
+# (Note: this feature is currently not supported under Windows.)
+freespace = 64
+
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs
 # produced by the analyzer.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -370,6 +370,26 @@ class Scheduler:
         while self.running:
             time.sleep(1)
 
+            # If not enough free diskspace is available, then we print an
+            # error message and wait another round. (This check is ignored
+            # when freespace is set to zero.)
+            if self.cfg.cuckoo.freespace:
+                # Resolve the full base path to the analysis folder, just in
+                # case somebody decides to make a symlink out of it.
+                dir_path = os.path.join(CUCKOO_ROOT, "storage", "analyses")
+
+                # TODO windows support
+                if hasattr(os, "statvfs"):
+                    s = os.statvfs(dir_path)
+
+                    # Free diskspace in megabytes.
+                    avail = (s.f_bavail * s.f_frsize) / 1024 / 1024
+
+                    if avail < self.cfg.cuckoo.freespace:
+                        log.error("Not enough free diskspace! (Only %d MB!)" %
+                                  avail)
+                        continue
+
             # If no machines are available, it's pointless to fetch for
             # pending tasks. Loop over.
             if machinery.availables() == 0:


### PR DESCRIPTION
Small feature which checks the available disk space before starting a new task. This way, if the disk Cuckoo is running on runs out of disk space, we don't start analysis and don't get nasty exceptions all over the place when writing the reports, dropped files, etc.
The minimum size is configurable (in MB).

Two improvements might be necessary:
- Windows support (for linux and macosx, `os.statvfs()` suffices.)
- Multiple VM support (i.e., check the minimum free disk space multiplied by the amount of configured/running VMs - needs some extra thoughts with regards to the VM tags stuff.)
