### PR TITLE
Need to return snapshotCurrent or an error is thrown

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -496,7 +496,7 @@ class LibVirtMachinery(Machinery):
             self._disconnect(conn)
 
         if snap:
-            return snap
+            return vm.snapshotCurrent(flags=0)
 
         # If no current snapshot, get the last one.
         conn = self._connect()


### PR DESCRIPTION
An error was occurring in KVM when starting attempting to use the current snapshot and not using snapshot labels.
