### PR TITLE
Better check antivirus sig available

### DIFF
--- a/web/templates/analysis/static/_antivirus.html
+++ b/web/templates/analysis/static/_antivirus.html
@@ -1,5 +1,5 @@
 <section id="static_antivirus">
-    {% if analysis.virustotal %}
+    {% if analysis.virustotal and analysis.virustotal.response_code %}
     <table class="table table-striped table-bordered">
         <tr>
             <th>Antivirus</th>
@@ -23,6 +23,6 @@
         {% endfor %}
     </table>
     {% else %}
-    Antivirus signatures not available.
+    No antivirus signatures available.
     {% endif %}
 </section>


### PR DESCRIPTION
cause the msg is not displayed in the GUI when no sigs are available.
From VT API: 

The API response format is a JSON object containing at least the following two properties:

response_code: if the item you searched for was not present in VirusTotal's dataset this result will be 0. If the requested item is still queued for analysis it will be -2. If the item was indeed present and it could be retrieved it will be 1. Any other case is detailed in the following sections.
verbose_msg: provides verbose information regarding the response_code property.
Whenever you exceed the public API request rate limit a 204 HTTP status code is returned.
