### PR TITLE
Click on the upper, right corner instead of the lower, right corner

### DIFF
--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -76,7 +76,7 @@ def move_mouse():
 
 def click_mouse():
     # Move mouse to bottom-right position.
-    USER32.SetCursorPos(RESOLUTION["x"], RESOLUTION["y"])
+    USER32.SetCursorPos(RESOLUTION["x"], 0)
     # Mouse down.
     USER32.mouse_event(2, 0, 0, 0, None)
     KERNEL32.Sleep(50)


### PR DESCRIPTION
Click on the upper, right corner instead of the lower right corner as the lower, right corner is the show/hide desktop button on Windows 7.
