### PR TITLE
Sort order for signatures. Allows to write meta-signatures combining the...

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -640,6 +640,7 @@ class Signature(object):
     enabled = True
     minimum = None
     maximum = None
+    order = 0
 
     evented = False
     filter_processnames = set()

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -392,8 +392,12 @@ class RunSignatures(object):
                         if sig in complete_list:
                             complete_list.remove(sig)
 
+        matched.sort(key=lambda key: key["severity"])
+        self.results["signatures"] = matched
+
         # Compat loop for old-style (non evented) signatures.
         if complete_list:
+            complete_list.sort(key=lambda module: module.order)
             log.debug("Running non-evented signatures")
 
             for signature in complete_list:
@@ -401,12 +405,9 @@ class RunSignatures(object):
                 # If the signature is matched, add it to the list.
                 if match:
                     matched.append(match)
-
-        if matched:
-            # Sort the matched signatures by their severity level.
-            matched.sort(key=lambda key: key["severity"])
-
-        self.results["signatures"] = matched
+                    # Sort the matched signatures by their severity level.
+                    matched.sort(key=lambda key: key["severity"])
+                    self.results["signatures"] = matched
 
 class RunReporting:
     """Reporting Engine.


### PR DESCRIPTION
... results of base signatures to a specific detection. I sorted the classic signatures by order and modified data entry of previously matched signatures into the result.
