### PR TITLE
Fixed wrong md5 in /browse page.

### DIFF
--- a/utils/web.py
+++ b/utils/web.py
@@ -68,7 +68,7 @@ def browse():
             task["processed"] = True
 
         if row.category == "file":
-            sample = db.view_sample(row.sample_id)
+            sample = db.view_sample(row.id)
             task["md5"] = sample.md5
 
         tasks.append(task)


### PR DESCRIPTION
The browser page shows the md5 of the wrong sample. The view_sample function uses task_id to fetch the corresponding sample instead of sample_id. 
