### PR TITLE
Ignore missing start or completion time for tasks

### DIFF
--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -20,6 +20,7 @@ from lib.cuckoo.core.database import TASK_FAILED_PROCESSING
 
 def timestamp(dt):
     """Returns the timestamp of a datetime object."""
+    if not dt: return None
     return time.mktime(dt.timetuple())
 
 @require_safe


### PR DESCRIPTION
Some of my tasks are without a completion time (something exploded during analysis). This new view crashes as it assumes that every task has both start and completion times.
