### PR TITLE
Moved deletion of secondary tables before the deletion of machine table ...

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -395,6 +395,10 @@ class Database(object):
 
     def clean_machines(self):
         """Clean old stored machines and related tables."""
+        # Secondary table.
+        # TODO: this is better done via cascade delete.
+        self.engine.execute(machines_tags.delete())
+
         session = self.Session()
         try:
             session.query(Machine).delete()
@@ -404,9 +408,6 @@ class Database(object):
             session.rollback()
         finally:
             session.close()
-        # Secondary table.
-        # TODO: this is better done via cascade delete.
-        self.engine.execute(machines_tags.delete())
 
     def add_machine(self,
                     name,


### PR DESCRIPTION
...to satisfy the constraints, otherwise the deletion of records in MySQL and PostgreSQL would fail, as the constraints aren't satisfied. This caused the database not to be pruned when using MySQL and PostgreSQL, and the number of machines in the database starts to grow with every restart.
