### PR TITLE
Update packages.py

### DIFF
--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -21,7 +21,7 @@ def choose_package(file_type, file_name):
     elif "Rich Text Format" in file_type or \
          "Microsoft Word" in file_type or \
          "Microsoft Office Word" in file_type or \
-         ("Composite Document File" in file_type and not "Installer" in file_type) or \
+         ("Composite Document File" in file_type and not "Installer" in file_type) and \
          file_name.endswith(".docx") or \
          file_name.endswith(".doc") or \
          file_name.endswith(".rtf"):


### PR DESCRIPTION
this change is based on a comment by dmaciejak  

prevents wrong detection of office files (before: some xls were detected as composite file and cuckoo tried to start them with ms word)
