### PR TITLE
Update processActionArguments in maec40.py

### DIFF
--- a/modules/reporting/maec40.py
+++ b/modules/reporting/maec40.py
@@ -318,10 +318,8 @@ class MAEC40Report(Report):
             elif parameter_name in parameter_mappings_dict and "associated_argument_vocab" not in parameter_mappings_dict[parameter_name]:
                 arguments_list.append({"argument_value": argument_value,
                                        "argument_name": {"value": parameter_mappings_dict[parameter_name]["associated_argument_name"]}})
-        if arguments_list:
-            return arguments_list
-        else:
-            return None
+        return arguments_list
+        
 
     def processActionAssociatedObjects(self, associated_objects_dict, parameter_list):
         """Processes a dictionary of parameters that should be mapped to Associated Objects in the Action


### PR DESCRIPTION
processActionArguments now returns arguments_list regardless if it is populated or a 0-length list.

Received error attempting to generate a MAEC report for a specific sample:
"Failed to generate MAEC 4.0.1 report: object of type 'NoneType' has no len(). Traceback pointed to line 48 of action.py in CYBOX module, attempting to find len of self.action_arguments.  Found processActionArguments in modules/reporting/MAEC40.py returned either the arguments_list, or None.  arguments_list is already initialized to a 0-length list, so modified processActionArguments to just return arguments_list.  Fixed the issue.
