### PR TITLE
Support for old Adobe Reader 7

### DIFF
--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -14,6 +14,7 @@ class PDF(Package):
     def get_path(self):
         adobe = os.path.join(os.getenv("ProgramFiles"), "Adobe")
         paths = [
+            os.path.join(adobe, "Acrobat 7.0", "Reader", "AcroRd32.exe"),
             os.path.join(adobe, "Reader 8.0", "Reader", "AcroRd32.exe"),
             os.path.join(adobe, "Reader 9.0", "Reader", "AcroRd32.exe"),
             os.path.join(adobe, "Reader 10.0", "Reader", "AcroRd32.exe"),


### PR DESCRIPTION
Some older files are only working with AR 7.0. This adds support for AR 7.0 without any trouble.
