### PR TITLE
Adds imphash to static.py. Needs at least pefile 1.2.10-139 to work

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -211,6 +211,19 @@ class PortableExecutable:
 
         return infos
 
+
+    def _get_imphash(self):
+        """Gets imphash.
+        @return: imphash string or None.
+        """
+        if not self.pe:
+            return None
+
+        imphash = self.pe.get_imphash()
+
+        return imphash
+
+
     def run(self):
         """Run analysis.
         @return: analysis results dict or None.
@@ -230,6 +243,7 @@ class PortableExecutable:
         results["pe_sections"] = self._get_sections()
         results["pe_resources"] = self._get_resources()
         results["pe_versioninfo"] = self._get_versioninfo()
+        results["pe_imphash"] = self._get_imphash()
         results["imported_dll_count"] = len([x for x in results["pe_imports"] if x.get("dll")])
         return results
 


### PR DESCRIPTION
This implements the imphash technique described in the following blog post:
https://www.mandiant.com/blog/tracking-malware-import-hashing/

Needs pefile 1.2.10-139 or greater.
