### PR TITLE
Clarify correct version of MAEC python library to install.

### DIFF
--- a/docs/book/src/installation/host/requirements.rst
+++ b/docs/book/src/installation/host/requirements.rst
@@ -39,7 +39,7 @@ The following libraries are not strictly required, but their installation is rec
     * `Django`_ (Optional): for using the web interface (use release 1.5 or above).
     * `Pefile`_ (Optional): used for static analysis of PE32 binaries.
     * `Volatility`_ (Optional): used for forensic analysis on memory
-    * `MAEC Python bindings`_ (Optional): used for MAEC reporting (use release 4.0 or above).
+    * `MAEC Python bindings`_ (Optional): used for MAEC reporting (use a release >=4.0, but <4.1).
     * `Chardet`_ (Optional): used for detecting string encoding.
 
 Some of them are already packaged in Debian/Ubuntu and can be installed with the following command::
@@ -48,7 +48,7 @@ Some of them are already packaged in Debian/Ubuntu and can be installed with the
 
 Except for *python-magic*, *python-dpkt* and *python-libvirt*, the others can be installed through ``pip`` too::
 
-    $ sudo pip install jinja2 pymongo bottle pefile maec django chardet
+    $ sudo pip install jinja2 pymongo bottle pefile maec==4.0.1.0 django chardet
 
 *Yara* and *Pydeep* will have to be installed manually, so please refer to their websites.
 
@@ -67,7 +67,7 @@ If want to use KVM it's packaged too and you can install it with the following c
 .. _Django: https://www.djangoproject.com/
 .. _Pefile: http://code.google.com/p/pefile/
 .. _Volatility: http://code.google.com/p/volatility/
-.. _MAEC Python bindings: https://pypi.python.org/pypi/maec
+.. _MAEC Python bindings: https://pypi.python.org/pypi/maec/4.0.1.0
 .. _Chardet: https://pypi.python.org/pypi/chardet
 
 Virtualization Software


### PR DESCRIPTION
Now that [MAEC version 4.1](http://maec.mitre.org/language/version4.1/) has been released, users should still be installing a 4.0.1.X version of python-maec. We will shortly be updating the MAEC mappings to reflect updates in MAEC 4.1, but until then, we want users to install the correct version. 

The future update will also rename occurrences of `maec40` to `maec41` to avoid confusion.
