### PR TITLE
Configure temporary directory using conf file

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -43,6 +43,9 @@ max_analysis_count = 0
 # (Note: this feature is currently not supported under Windows.)
 freespace = 64
 
+# Temporary directory to use when upload files
+tmppath = /tmp
+
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs
 # produced by the analyzer.

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -12,6 +12,8 @@ import xmlrpclib
 from datetime import datetime
 
 from lib.cuckoo.common.exceptions import CuckooOperationalError
+from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.constants import CUCKOO_ROOT
 
 try:
     import chardet
@@ -118,7 +120,8 @@ def store_temp_file(filedata, filename):
     # reduce length (100 is arbitrary)
     filename = filename[:100]
 
-    tmppath = tempfile.gettempdir()
+    options = Config(os.path.join(CUCKOO_ROOT, "conf", "cuckoo.conf"))
+    tmppath = options.cuckoo.tmppath
     targetpath = os.path.join(tmppath, "cuckoo-tmp")
     if not os.path.exists(targetpath):
         os.mkdir(targetpath)


### PR DESCRIPTION
How I was said in [issue 294](https://github.com/cuckoobox/cuckoo/pull/294), I changed the store_temp_file function to read the cuckoo.conf and use the default temp directory, then we can change the cuckoo.conf to avoid some issues
