### PR TITLE
Update analyzer packages to fix Path issue on 64 bit guest

### DIFF
--- a/analyzer/windows/modules/packages/applet.py
+++ b/analyzer/windows/modules/packages/applet.py
@@ -5,7 +5,6 @@
 import os
 import string
 import random
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/html.py
+++ b/analyzer/windows/modules/packages/html.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/ie.py
+++ b/analyzer/windows/modules/packages/ie.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/jar.py
+++ b/analyzer/windows/modules/packages/jar.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process

--- a/analyzer/windows/modules/packages/xls.py
+++ b/analyzer/windows/modules/packages/xls.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
-import platform
 
 from lib.common.abstracts import Package
 from lib.api.process import Process


### PR DESCRIPTION
Detects system platform and uses "ProgramFiles(x86)" environment variable if on 64 bit Windows, otherwise defaults to the "ProgramFiles" environment variable.  For use in determining path of Office, Adobe, Java, and IE.  
