### PR TITLE
The default BPF misses port 8000 traffic 

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -54,12 +54,15 @@ class Sniffer(Auxiliary):
         pargs.extend(["-w", file_path])
         pargs.extend(["host", host])
         # Do not capture XMLRPC agent traffic.
-        pargs.extend(["and", "not", "(", "host", host, "and", "port",
-                      str(CUCKOO_GUEST_PORT), ")"])
+        pargs.extend(["and", "not", "(","dst", "host", host, "and", "dst", "port", 
+                      str(CUCKOO_GUEST_PORT), ")", "and", "not", "(", "src", "host",
+                      host, "and", "src", "port", str(CUCKOO_GUEST_PORT),")"])
+
         # Do not capture ResultServer traffic.
-        pargs.extend(["and", "not", "(", "host",
-                      str(Config().resultserver.ip), "and", "port",
-                      str(Config().resultserver.port), ")"])
+        pargs.extend(["and", "not", "(", "dst", "host", str(Config().resultserver.ip),
+                      "and", "dst", "port", str(Config().resultserver.port), ")", "and",
+                      "not", "(", "src", "host", str(Config().resultserver.ip), "and", 
+                      "src", "port", str(Config().resultserver.port),")"])
 
         if bpf:
             pargs.extend(["and", bpf])


### PR DESCRIPTION
Make the default BPF a bit tighter. The default will cause cuckoo to miss all port 8000 traffic. Been meaning to send this for a bit.  Cuckoo used to be blind to all Neutrino EK traffic (port 8000) due to the default BPF although it seems to be dead now.  It also seems that the default BPF has gone through a couple of changes although the current version still needs an update it seems.
