### PR TITLE
Logging all yara errors.

### DIFF
--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -218,7 +218,7 @@ class File:
         if HAVE_YARA:
             if os.path.getsize(self.file_path) > 0:
                 try:
-                    rules = yara.compile(rulepath)
+                    rules = yara.compile(rulepath, error_on_warning=True)
 
                     for match in rules.match(self.file_path):
                         strings = []
@@ -237,7 +237,10 @@ class File:
                         matches.append({"name": match.rule,
                                         "meta": match.meta,
                                         "strings": strings})
-                except yara.Error as e:
+                except (yara.Error,
+                        yara.SyntaxError,
+                        yara.TimeoutError,
+                        yara.WarningError) as e:
                     log.warning("Unable to match Yara signatures: %s", e)
         else:
             if not File.notified_yara:


### PR DESCRIPTION
With the current code, if you have some errors in yara rules (a duplicated include in index_binary.yar for example) the processor don't even work. The worst part is that is not logged :(

This patch enables `error_on_warning` in yara.compile and catch all possible yara exceptions.
