### PR TITLE
Fixed missing parentheses in jar.py

### DIFF
--- a/analyzer/windows/modules/packages/jar.py
+++ b/analyzer/windows/modules/packages/jar.py
@@ -15,7 +15,7 @@ class Jar(Package):
         if os.getenv("ProgramFiles(x86)"):
             javax86 = os.path.join(os.getenv("ProgramFiles(x86)"), "Java")
         else:
-            javax86 = os.path.join(os.getenv("ProgramFiles", "Java")
+            javax86 = os.path.join(os.getenv("ProgramFiles"), "Java")
 
         java32 = os.path.join(os.getenv("ProgramFiles"), "Java")
             


### PR DESCRIPTION
Missing parenthesis in jar.py causes analysis to fail
