### PR TITLE
Update resultserver.py

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -342,7 +342,10 @@ class FileUpload(object):
                 self.fd.write("... (truncated)")
                 break
 
-            chunk = self.handler.read_any()
+            try:
+                chunk = self.handler.read_any()
+            except:
+                break
 
         log.debug("Uploaded file length: {0}".format(self.fd.tell()))
 


### PR DESCRIPTION
try catch on chunk handler read, otherwise fails without exiting the loop when reading fails.
