### PR TITLE
convert dll name to printable characters

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -89,7 +89,7 @@ class PortableExecutable:
                         symbols.append(symbol)
 
                     imports_section = {}
-                    imports_section["dll"] = entry.dll
+                    imports_section["dll"] = convert_to_printable(entry.dll)
                     imports_section["imports"] = symbols
                     imports.append(imports_section)
                 except:


### PR DESCRIPTION
If a sample has a invalid utf8 character in the DLL import it will cause JSONDump and MongoDB reporting to not error out.  This change will drop the invalid utf8 character.

The dll name I ran across had "\x97" in the import section.

JSONDump error
UnicodeDecodeError: 'utf8' codec can't decode byte 0x97 in position 12: invalid start byte

MongoDB error:
UnicodeDecodeError: 'utf8' codec can't decode byte 0x97 in position 12: invalid start byte
