### PR TITLE
limit number of concurrently executing machines

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -37,6 +37,11 @@ process_results = on
 # This can be used together with a watchdog to mitigate risk of memory leaks.
 max_analysis_count = 0
 
+# Limit the number of concurrently executing analysis machines.
+# This may be useful on systems with limited resources.
+# Set to 0 to disable any limits.
+max_machines_count = 0
+
 # Minimum amount of free space (in MB) available before starting a new task. 
 # This tries to avoid failing an analysis because the reports can't be written 
 # due out-of-diskspace errors. Setting this value to 0 disables the check.

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -498,6 +498,12 @@ class Scheduler:
                                   space_available)
                         continue
 
+            # Have we limited the number of concurrently executing machines?
+            if self.cfg.cuckoo.max_machines_count > 0:
+                # Are too many running?
+                if len(machinery.running()) >= self.cfg.cuckoo.max_machines_count:
+                    continue
+
             # If no machines are available, it's pointless to fetch for
             # pending tasks. Loop over.
             if not machinery.availables():


### PR DESCRIPTION
(Moved this into the scheduler.)

Say you have six different VMs with six different configurations and you want to test your sample against all of them, but not at the same time due to limited system resources. This option lets you limit the total number of concurrent analysis machines executing at the same time. So you can queue up a bunch of jobs without blowing out your RAM.
