### PR TITLE
Fix memory leak if using a old version of python-magic

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -51,6 +51,11 @@ class PortableExecutable:
                 file_type = magic.from_buffer(data)
             except Exception:
                 return None
+        finally:
+            try:
+                ms.close()
+            except:
+                pass
 
         return file_type
 


### PR DESCRIPTION
This will fix a memory leak if a older version of python-magic is installed.  Closes the magic database the same way as in lib/cuckoo/common/objects.py.
