### PR TITLE
Cuckoo not injecting into child procs due to bug in pipe command parsing

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -249,7 +249,7 @@ class PipeHandler(Thread):
                 if "," not in data:
                     if data.isdigit():
                         process_id = int(data)
-                elif data.count(",") == 2:
+                elif data.count(",") == 1:
                     process_id, param = data.split(",")
                     thread_id = None
                     if process_id.isdigit():


### PR DESCRIPTION
Looks like one of the code style clean ups introduced a bug in the analyzer's pipe handler.  Subsequently, cuckoo was no longer injecting into most spawned child processes and often terminated analysis early.

Possibly fixes other recent github issue/s relating to missing network api calls but comms still captured from samples.
