### PR TITLE
Incorrect option splicing for options string in submission view.

### DIFF
--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -36,12 +36,12 @@ def index(request):
 
         if request.POST.get("free"):
             if options:
-                options += "&"
+                options += ","
             options += "free=yes"
 
         if request.POST.get("process_memory"):
             if options:
-                options += "&"
+                options += ","
             options += "procmemdump=yes"
 
         db = Database()


### PR DESCRIPTION
analyzer/windows/lib/core/config.py for the splits on ',' but for "free" and "procmemdump" in web/submission/views.py the options string is spliced together with '&'
