### PR TITLE
Update requirements.rst

### DIFF
--- a/docs/book/src/installation/host/requirements.rst
+++ b/docs/book/src/installation/host/requirements.rst
@@ -52,7 +52,7 @@ Some of them are already packaged in Debian/Ubuntu and can be installed with the
 
 Except for *python-magic*, *python-dpkt* and *python-libvirt*, the others can be installed through ``pip`` too::
 
-    $ sudo pip install jinja2 pymongo bottle pefile maec==4.0.1.0 django chardet
+    $ sudo pip install jinja2 pymongo bottle pefile cybox==2.0.1.4 maec==4.0.1.0 django chardet
 
 *Yara* and *Pydeep* will have to be installed manually, so please refer to their websites.
 


### PR DESCRIPTION
Installing maec==4.0.1.0 fails, because it is apprently incompatible with the most recent cybox version. The installation just succeeds when explicitly specifying cybox==2.0.1.4.

Further reference: https://github.com/MAECProject/python-maec/issues/25
