### PR TITLE
fix for Machine/Task Correlation when performing a db.fetch

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -533,15 +533,17 @@ class Scheduler:
                     self.stop()
             else:
                 # Fetch a pending analysis task.
-                task = self.db.fetch()
+                #TODO: this fixes only submissions by --machine, need to add other attributes (tags etc.)
+                for machine in self.db.get_available_machines():
 
-                if task:
-                    log.debug("Processing task #%s", task.id)
-                    self.total_analysis_count += 1
+                    task = self.db.fetch(machine=machine.name)
+                    if task:
+                        log.debug("Processing task #%s", task.id)
+                        self.total_analysis_count += 1
 
-                    # Initialize and start the analysis manager.
-                    analysis = AnalysisManager(task, errors)
-                    analysis.start()
+                        # Initialize and start the analysis manager.
+                        analysis = AnalysisManager(task, errors)
+                        analysis.start()
 
             # Deal with errors.
             try:


### PR DESCRIPTION
This fix partially solves issue #302 (solves only the machine correlation and not the tag correlation)

Description of the change:
In lib/cuckoo/core/database.py: 
1. added an optional 'machine' argument for the fetch function - if supplied , the fetching will be done only for this machine
2. added a get_available_machines function - returns all available machines
In lib/cuckoo/core/scheduler.py:
1. in the 'start' function - fetching is done in a loop to fetch tasks for each available machine seperately

Note: This code was written in Check Point Software Technologies LTD.
