### PR TITLE
Fixed TEMPLATE_DIRS setting must be a tuple

### DIFF
--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -114,7 +114,7 @@ ROOT_URLCONF = 'web.urls'
 WSGI_APPLICATION = 'web.wsgi.application'
 
 TEMPLATE_DIRS = (
-    "templates"
+    "templates",
 )
 
 INSTALLED_APPS = (


### PR DESCRIPTION
When running `python manage.py runserver` into cuckoo/web directory Django raised the following exception:

`django.core.exceptions.ImproperlyConfigured: The TEMPLATE_DIRS setting must be a tuple. Please fix your settings.`
