### PR TITLE
Better Signatures

### DIFF
--- a/docs/book/src/customization/signatures.rst
+++ b/docs/book/src/customization/signatures.rst
@@ -261,6 +261,65 @@ You can find many more example of both evented and traditional signatures in our
 
 .. _`community repository`: https://github.com/cuckoobox/community
 
+Matches
+=======
+
+Starting from version 1.2, signatures are able to log exactly what triggered
+the signature. This allows users to better understand why this signature is
+present in the log, and to be able to better focus malware analysis.
+
+Two helpers have been included in order to specify matching data.
+
+.. function:: Signature.add_match(process, type, match)
+
+    Adds a match to the signature. Can be called several times for the same signature.
+
+    :param process: process dictionary (same as the ``on_call`` argument). Should be ``None`` except when used in evented signatures.
+    :type process: dict
+    :param type: nature of the matching data. Can be anything (ex: ``'file'``, ``'registry'``, etc.). If match is composed of api calls (when used in evented signatures), should be ``'api'``.
+    :type type: string
+    :param match: matching data. Can be a single element or a list of elements. An element can be a string, a dict or an API call (when used in evented signatures).
+
+    Example Usage, with a single element:
+
+    .. code-block:: python
+        :linenos:
+
+        self.add_match(None, 'url', "http://malicious_url_detected.com")
+
+    Example Usage, with a more complex signature, needing several API calls to be triggered:
+
+    .. code-block:: python
+        :linenos:
+
+        self.signs = []
+        self.signs.append(first_api_call)
+        self.signs.append(second_api_call)
+        self.add_match(process, 'api', self.signs)
+
+.. function:: Signature.has_matches()
+
+    Checks whether the current signature has any matching data registered. Returns ``True`` in case it does, otherwise returns ``False``.
+
+    This can be used to easily add several matches for the same signature. If you want to do so, make sure that all the api calls are scanned by making sure that ``on_call`` never returns ``True``. Then, use ``on_complete`` with ``has_matches`` so that the signature is triggered if any match was previously added.
+
+    :rtype: boolean
+
+    Example Usage, from the `network_tor` signature:
+
+    .. code-block:: python
+        :linenos:
+
+        def on_call(self, call, process):
+            if self.check_argument_call(call,
+                                        pattern="Tor Win32 Service",
+                                        api="CreateServiceA",
+                                        category="services"):
+                self.add_match(process, 'api', call)
+
+        def on_complete(self):
+            return self.has_matches()
+
 Helpers
 =======
 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -885,6 +885,33 @@ class Signature(object):
 
         return None
 
+    def add_match(self, process, type, match):
+        """Adds a match to the signature data.
+        @param process: The process triggering the match.
+        @param type: The type of matching data (ex: 'api', 'mutex', 'file', etc.)
+        @param match: Value or array of values triggering the match.
+        """
+        signs = []
+        if isinstance(match, list):
+            for item in match:
+                signs.append({ 'type': type, 'value': item })
+        else:
+            signs.append({ 'type': type, 'value': match })
+
+        process_summary = None
+        if process:
+            process_summary = {}
+            process_summary['process_name'] = process['process_name']
+            process_summary['process_id'] = process['process_id']
+
+        self.data.append({ 'process': process_summary, 'signs': signs })
+
+    def has_matches(self):
+        """Returns true if there is matches (data is not empty)
+        @return: boolean indicating if there is any match registered
+        """
+        return len(self.data) > 0
+
     def on_call(self, call, process):
         """Notify signature about API call. Return value determines
         if this signature is done or could still match.

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -46,6 +46,7 @@ class ParseProcessLog(list):
         self.first_seen = None
         self.calls = self
         self.lastcall = None
+        self.call_id = 0
 
         if os.path.exists(log_path) and os.stat(log_path).st_size > 0:
             self.parse_first_and_reset()
@@ -91,6 +92,7 @@ class ParseProcessLog(list):
     def reset(self):
         self.fd.seek(0)
         self.lastcall = None
+        self.call_id = 0
 
     def compare_calls(self, a, b):
         """Compare two calls for equality. Same implementation as before netlog.
@@ -130,6 +132,9 @@ class ParseProcessLog(list):
             nextcall["repeated"] += 1
             self.lastcall = None
             self.wait_for_lastcall()
+
+        nextcall["id"] = self.call_id
+        self.call_id += 1
 
         return nextcall
 

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -482,8 +482,9 @@ class Pcap:
                 self._add_hosts(connection)
 
                 if ip.p == dpkt.ip.IP_PROTO_TCP:
-
                     tcp = ip.data
+                    if not isinstance(tcp, dpkt.tcp.TCP):
+                        tcp = dpkt.tcp.TCP(tcp)
 
                     if len(tcp.data) > 0:
                         connection["sport"] = tcp.sport
@@ -494,6 +495,8 @@ class Pcap:
                         continue
                 elif ip.p == dpkt.ip.IP_PROTO_UDP:
                     udp = ip.data
+                    if not isinstance(udp, dpkt.udp.UDP):
+                        udp = dpkt.udp.UDP(udp)
 
                     if len(udp.data) > 0:
                         connection["sport"] = udp.sport
@@ -502,6 +505,9 @@ class Pcap:
                         self.udp_connections.append(connection)
                 elif ip.p == dpkt.ip.IP_PROTO_ICMP:
                     icmp = ip.data
+                    if not isinstance(icmp, dpkt.icmp.ICMP):
+                        icmp = dpkt.icmp.ICMP(icmp)
+
                     self._icmp_dissect(connection, icmp)
             except AttributeError:
                 continue

--- a/web/analysis/templatetags/analysis_tags.py
+++ b/web/analysis/templatetags/analysis_tags.py
@@ -1,6 +1,4 @@
-from django import template
-
-register = template.Library()
+from django.template.defaultfilters import register
 
 @register.filter("mongo_id")
 def mongo_id(value):
@@ -13,3 +11,8 @@ def mongo_id(value):
 
     # Return value
     return unicode(value)
+
+@register.filter("is_dict")
+def is_dict(value):
+	"""Checks if value is an instance of dict"""
+	return isinstance(value, dict)

--- a/web/analysis/urls.py
+++ b/web/analysis/urls.py
@@ -10,6 +10,7 @@ urlpatterns = patterns("",
     url(r"^remove/(?P<task_id>\d+)/$", "analysis.views.remove"),
     url(r"^chunk/(?P<task_id>\d+)/(?P<pid>\d+)/(?P<pagenum>\d+)/$", "analysis.views.chunk"),
     url(r"^filtered/(?P<task_id>\d+)/(?P<pid>\d+)/(?P<category>\w+)/$", "analysis.views.filtered_chunk"),
+    url(r"^search/(?P<task_id>\d+)/$", "analysis.views.search_behavior"),
     url(r"^search/$", "analysis.views.search"),
     url(r"^pending/$", "analysis.views.pending"),
 )

--- a/web/templates/analysis/behavior/_api_call.html
+++ b/web/templates/analysis/behavior/_api_call.html
@@ -1,0 +1,48 @@
+<td>{{call.timestamp}}</td>
+<td><strong>{{call.api}}</strong></td>
+<td style="word-wrap: break-word;">
+    {% for argument in call.arguments %}
+        <span class="gray">{{argument.name}}:</span>
+        <span class="mono">
+            {% if argument.name == "Registry" and call.category == "registry" %}
+                {% if argument.value == "0x80000000" %}
+                    HKEY_CLASSES_ROOT
+                {% elif argument.value == "0x80000001" %}
+                    HKEY_CURRENT_USER
+                {% elif argument.value == "0x80000002" %}
+                    HKEY_LOCAL_MACHINE
+                {% elif argument.value == "0x80000003" %}
+                    HKEY_USERS
+                {% elif argument.value == "0x80000004" %}
+                    HKEY_PERFORMANCE_DATA
+                {% elif argument.value == "0x80000005" %}
+                    HKEY_CURRENT_CONFIG
+                {% elif argument.value == "0x80000006" %}
+                    HKEY_DYN_DATA
+                {% else %}
+                    {{argument.value}}
+                {% endif %}
+            {% else %}
+                {{argument.value}}
+            {% endif %}
+        </span><br />
+    {% endfor %}
+</td>
+<td>
+    {% if call.status %}
+        success
+    {% else %}
+        failed
+    {% endif %}
+</td>
+<td><span class="mono">{{call.return}}</span></td>
+<td>
+    {% if call.repeated > 0 %}
+        {{call.repeated}}
+        {% if call.repeated > 1 %}
+            times
+        {% else %}
+            time
+        {% endif %}
+    {% endif %}
+</td>

--- a/web/templates/analysis/behavior/_chunk.html
+++ b/web/templates/analysis/behavior/_chunk.html
@@ -11,55 +11,8 @@
     </thead>
     <tbody>
     {% for call in chunk.calls %}
-        <tr class="{{call.category}}">
-            <td>{{call.timestamp}}</td>
-            <td><strong>{{call.api}}</strong></td>
-            <td style="word-wrap: break-word;">
-                {% for argument in call.arguments %}
-                    <span class="gray">{{argument.name}}:</span>
-                    <span class="mono">
-                        {% if argument.name == "Registry" and call.category == "registry" %}
-                            {% if argument.value == "0x80000000" %}
-                                HKEY_CLASSES_ROOT
-                            {% elif argument.value == "0x80000001" %}
-                                HKEY_CURRENT_USER
-                            {% elif argument.value == "0x80000002" %}
-                                HKEY_LOCAL_MACHINE
-                            {% elif argument.value == "0x80000003" %}
-                                HKEY_USERS
-                            {% elif argument.value == "0x80000004" %}
-                                HKEY_PERFORMANCE_DATA
-                            {% elif argument.value == "0x80000005" %}
-                                HKEY_CURRENT_CONFIG
-                            {% elif argument.value == "0x80000006" %}
-                                HKEY_DYN_DATA
-                            {% else %}
-                                {{argument.value}}
-                            {% endif %}
-                        {% else %}
-                            {{argument.value}}
-                        {% endif %}
-                    </span><br />
-                {% endfor %}
-            </td>
-            <td>
-                {% if call.status %}
-                    success
-                {% else %}
-                    failed
-                {% endif %}
-            </td>
-            <td><span class="mono">{{call.return}}</span></td>
-            <td>
-                {% if call.repeated > 0 %}
-                    {{call.repeated}}
-                    {% if call.repeated > 1 %}
-                        times
-                    {% else %}
-                        time
-                    {% endif %}
-                {% endif %}
-            </td>
+        <tr class="{{call.category}}" id="call_{{call.id}}">
+            {% include "analysis/behavior/_api_call.html" %}
         </tr>
     {% endfor %}
     </tbody>

--- a/web/templates/analysis/behavior/_processes.html
+++ b/web/templates/analysis/behavior/_processes.html
@@ -22,7 +22,7 @@ function paginationbar(pages, page) {
         out += "<li"+alert_current_page(pages, page)+"><a href=\"#\">"+pages+"</a></li>";
     return out;
 }
-function load_chunk(pid, pagenum) {
+function load_chunk(pid, pagenum, callback) {
     $("#process_"+pid+" div.calltable").load("/analysis/chunk/{{analysis.info.id}}/"+pid+"/"+pagenum+"/", function(data, status, xhr){
         if (status == "error") {
             $("#process_"+pid+" div.calltable").html("Error loading data. Please reload the page and if the error persists contact us.");
@@ -33,7 +33,41 @@ function load_chunk(pid, pagenum) {
                 var t = $(e.target);
                 load_chunk(t.parents("#process_"+pid).data("pid"), parseInt(t.text()));
             });
+            typeof callback === 'function' && callback();
         }
+    });
+}
+function show_tab(id, callback) {
+    // First, see if tab is already active. If it is, just run the callback
+    if ($('#' + id).hasClass('active')) {
+        typeof callback === 'function' && callback();
+    }
+    // Else, show the tab and run the callback once the tab is shown
+    else {
+        // Wait for tab to be shown
+        $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+            if ($(e.target).attr('href') == '#' + id) {
+                $('a[data-toggle="tab"]').off('shown.bs.tab');
+                typeof callback === 'function' && callback();
+            }
+        });
+
+        // Show the tab
+        $('a[href="#' + id + '"]').tab('show');
+    }
+}
+function go_to_api_call(pid, call_id) {
+    // Load corresponding chunk
+    pagenum = Math.floor(call_id / 100) + 1;
+    load_chunk(pid, pagenum, function () {
+        // Show behavior tab
+        show_tab('behavior', function () {
+            // Show process tab
+            show_tab('process_' + pid, function () {
+                // Scroll to call
+                $('#call_' + call_id).get(0).scrollIntoView(false);
+            });
+        });
     });
 }
 function load_filtered_chunk(pid, category) {
@@ -54,11 +88,13 @@ function load_filtered_chunk(pid, category) {
 
 <div class="tabbable">
     <ul class="nav nav-tabs">
+        <li><a href="#search" data-toggle="tab">Search</a></li>
     {% for process in analysis.behavior.processes %}
         <li {% if forloop.counter == 1 %}class="active"{% endif %}><a href="#process_{{process.process_id}}" data-toggle="tab">{{process.process_name}}</a></li>
     {% endfor %}
     </ul>
     <div class="tab-content">
+    {% include "analysis/behavior/_search.html" %}
     {% for process in analysis.behavior.processes %}
         <div class="tab-pane{% if forloop.counter == 1%} active{% endif %}" id="process_{{process.process_id}}" data-pid="{{process.process_id}}" data-length="{{process.calls|length}}">
             <div class="alert alert-info" style="text-align: center;"><b>{{process.process_name}}</b>, PID: <b>{{process.process_id}}</b>, Parent PID: {{process.parent_id}}</div>
@@ -83,6 +119,14 @@ function load_filtered_chunk(pid, category) {
                 $("#badge_process_{{process.process_id}}").click(function() { load_filtered_chunk({{process.process_id}}, "process"); });
                 $("#badge_services_{{process.process_id}}").click(function() { load_filtered_chunk({{process.process_id}}, "services"); });
                 $("#badge_sync_{{process.process_id}}").click(function() { load_filtered_chunk({{process.process_id}}, "synchronization"); });
+
+                $('.tab-content').on('click', '.call-link', function (event) {
+                    cid = $(this).attr('data-cid');
+                    pid = $(this).attr('data-pid');
+                    go_to_api_call(+pid, +cid);
+
+                    event.preventDefault();
+                });
             });
             </script>
 

--- a/web/templates/analysis/behavior/_search.html
+++ b/web/templates/analysis/behavior/_search.html
@@ -1,0 +1,28 @@
+<script type="text/javascript">
+$(function () {
+	$('#search button[type=submit]').on('click', function(event) {
+		action = $('form#search').attr('action');
+		data = $('form#search').serialize();
+		
+		$.post(action, data, function (data) {
+			$('#search-results').html(data);
+		});
+
+		event.preventDefault();
+	});
+});
+</script>
+
+<div class="tab-pane" id="search">
+	<form id='search' class="form-inline" role="form" action="{% url "analysis.views.search_behavior" analysis.info.id %}">
+		{% csrf_token %}
+    	<div class="form-group">
+        	<label class="sr-only" for="form_search">Search term</label>
+        	<input type="text" class="form-control" id="form_search" name="search" size=50 placeholder="Search term" />
+    	</div>
+		<button type="submit" class="btn btn-primary">Search</button>
+	</form>
+
+	<div id="search-results">
+	</div>
+</div>

--- a/web/templates/analysis/behavior/_search_results.html
+++ b/web/templates/analysis/behavior/_search_results.html
@@ -1,0 +1,31 @@
+
+<style type="text/css">
+.search-process {
+    background-color: #d9edf7;
+    font-weight: bold;
+}
+</style>
+<section id="search-results-section">
+    <h4>Results</h4>
+    {% if results %}
+        <table class="table table-bordered" style="table-layout: fixed;">
+            <tbody>
+                {% for match in results %}
+                    <tr><td colspan="7" class="search-process">Process: {{match.process.process_name}} ({{match.process.process_id}})</td></tr>
+                    {% for sign in match.signs %}
+                        <tr>
+                            {% include "analysis/behavior/_api_call.html" with call=sign %}
+                            <td>
+                                <a href='#' class='call-link' data-pid='{{match.process.process_id}}' data-cid='{{sign.id}}'>
+                                    <span class="glyphicon glyphicon-circle-arrow-right"></span>
+                                </a>
+                            </td>
+                        <tr>             
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>No results</p>
+    {% endif %}
+</section>

--- a/web/templates/analysis/overview/_signatures.html
+++ b/web/templates/analysis/overview/_signatures.html
@@ -1,8 +1,19 @@
+{% load analysis_tags %}
+
 <style type="text/css">
 .signature {
     padding: 5px;
     padding-left: 10px;
     margin-bottom: 5px;
+}
+
+.signature-process {
+    background-color: #d9edf7;
+    font-weight: bold;
+}
+
+.sign-key {
+    font-weight: bold;
 }
 </style>
 <section id="signatures">
@@ -19,11 +30,39 @@
             {% endif %}
             {{signature.description}}</div></a>
             <div id="signature_{{signature.name}}" class="collapse">
-                {% for sign in signature.data %}
-                    {% for key, value in sign.items %}
-                        <div><b>{{key}}</b>: {{value}}</div>
-                    {% endfor %}
-                {% endfor %}
+                <table class="table table-bordered" style="table-layout: fixed;">
+                    <tbody>
+                        {% for match in signature.data %}
+                            {% if match.process.process_name %}
+                                <tr><td colspan="7" class="signature-process">Process: {{match.process.process_name}} ({{match.process.process_id}})</td></tr>
+                            {% endif %}
+                            {% for sign in match.signs %}
+                                <tr>
+                                    {% if sign.type == 'api' %}
+                                        {% include "analysis/behavior/_api_call.html" with call=sign.value %}
+                                        <td>
+                                            <a href='#' class='call-link' data-pid='{{match.process.process_id}}' data-cid='{{sign.value.id}}'>
+                                                <span class="glyphicon glyphicon-circle-arrow-right"></span>
+                                            </a>
+                                        </td>
+                                    {% else %}
+                                        <td colspan="2">{{sign.type}}</td>
+                                        <td colspan="5">
+                                            {% if sign.value|is_dict %}
+                                                {% for key, value in  sign.value.items %}
+                                                    <span class='sign-key'>{{key}}:</span>
+                                                    <span class='sign-value'>{{value}}</span><br />
+                                                {% endfor %}
+                                            {% else %}
+                                                {{sign.value}}
+                                            {% endif %}
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         {% endfor %}
     {% else %}


### PR DESCRIPTION
Adds two helpers in signatures: `Signature.add_match()` and `Signature.has_matches()` to simplify addition of matching data to the signature (no need to update `Signature.data` manually anymore). It is now easy to add one (or several !) match(es) to the Signature.

Also adds support for better display of matching data in the web interface. Simple example, displaying a dict:

![image](https://cloud.githubusercontent.com/assets/35897/5394940/a736f6a8-8143-11e4-9566-19753ad101ca.png)

Support for special type `'api'` to use with evented signatures, in order to extract the matching API calls. Example:

![image](https://cloud.githubusercontent.com/assets/35897/5394963/f40835be-8143-11e4-8008-b52592d60cbd.png)

The arrow on the right allows the user to jump directly at this API call in the Behavioral tab.

With this functionality, it was also obvious to implement a simple search in the Behavioral logs:

![image](https://cloud.githubusercontent.com/assets/35897/5395007/a92f4e32-8144-11e4-8146-87483818106a.png)

For this change to really mean something, I also updated every signature in the community repository to use this feature. This way, you can click on every signature with a high level of confidence that it will display the matching data. See PR https://github.com/cuckoobox/community/pull/46
