### PR TITLE
Added possibility to specify Volatility profile per machine

### DIFF
--- a/conf/virtualbox.conf
+++ b/conf/virtualbox.conf
@@ -26,6 +26,11 @@ platform = windows
 # the analysis will fail.
 ip = 192.168.56.101
 
+# (Optional) Specify the volatility memory profile to use. If you do not specify
+# a profile Volatility will try to guess the profile (very rarely works reliably)
+# Example:
+# profile = WinXPSP3x86
+
 # (Optional) Specify the snapshot name to use. If you do not specify a snapshot
 # name, the VirtualBox MachineManager will use the current snapshot.
 # Example (Snapshot1 is the snapshot name):

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -101,6 +101,7 @@ class Machinery(object):
                 machine.label = machine_opts[self.LABEL]
                 machine.platform = machine_opts["platform"]
                 machine.tags = machine_opts.get("tags")
+                machine.profile = machine_opts.get("profile", None)
                 machine.ip = machine_opts["ip"]
 
                 # If configured, use specific network interface for this
@@ -133,7 +134,8 @@ class Machinery(object):
                                     interface=machine.interface,
                                     snapshot=machine.snapshot,
                                     resultserver_ip=ip,
-                                    resultserver_port=port)
+                                    resultserver_port=port,
+                                    profile=machine.profile)
             except (AttributeError, CuckooOperationalError) as e:
                 log.warning("Configuration details about machine %s "
                             "are missing: %s", machine_id, e)

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -71,6 +71,7 @@ class Machine(Base):
     status_changed_on = Column(DateTime(timezone=False), nullable=True)
     resultserver_ip = Column(String(255), nullable=False)
     resultserver_port = Column(String(255), nullable=False)
+    profile = Column(String(255), nullable=True)
 
     def __repr__(self):
         return "<Machine('{0}','{1}')>".format(self.id, self.name)
@@ -98,7 +99,7 @@ class Machine(Base):
         return json.dumps(self.to_dict())
 
     def __init__(self, name, label, ip, platform, interface, snapshot,
-                 resultserver_ip, resultserver_port):
+                 resultserver_ip, resultserver_port, profile):
         self.name = name
         self.label = label
         self.ip = ip
@@ -107,6 +108,7 @@ class Machine(Base):
         self.snapshot = snapshot
         self.resultserver_ip = resultserver_ip
         self.resultserver_port = resultserver_port
+        self.profile = profile
 
 class Tag(Base):
     """Tag describing anything you want."""
@@ -449,7 +451,7 @@ class Database(object):
 
     @classlock
     def add_machine(self, name, label, ip, platform, tags, interface,
-                    snapshot, resultserver_ip, resultserver_port):
+                    snapshot, resultserver_ip, resultserver_port, profile):
         """Add a guest machine.
         @param name: machine id
         @param label: machine label
@@ -460,6 +462,7 @@ class Database(object):
         @param snapshot: snapshot name to use instead of the current one, if configured
         @param resultserver_ip: IP address of the Result Server
         @param resultserver_port: port of the Result Server
+        @param profile: profile String for volatility
         """
         session = self.Session()
         machine = Machine(name=name,
@@ -469,7 +472,8 @@ class Database(object):
                           interface=interface,
                           snapshot=snapshot,
                           resultserver_ip=resultserver_ip,
-                          resultserver_port=resultserver_port)
+                          resultserver_port=resultserver_port,
+                          profile=profile)
         # Deal with tags format (i.e., foo,bar,baz)
         if tags:
             for tag in tags.replace(" ", "").split(","):


### PR DESCRIPTION
Added a profile option in the config file (virtualbox.conf) to specify a volatility profile, bypassing auto-detection and speeding up the analysis of the submissions.
