### PR TITLE
Exception handling for EADDRNOTAVAIL when starting the ResultServer

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -60,6 +60,21 @@ class ResultServer(SocketServer.ThreadingTCPServer, object):
                     log.warning("Cannot bind ResultServer on port %s, "
                                 "trying another port.", self.port)
                     self.port += 1
+                # In Linux /usr/include/asm-generic/errno.h:
+                # EADDRNOTAVAIL 99 (Cannot assign requested address)
+                # In Mac OS x:
+                # EADDRNOTAVAIL 49 (Cannot assign requested address)
+                elif e.errno == 99 or e.errno == 49:
+                    raise CuckooCriticalError("Unable to bind ResultServer on "
+                                              "{0}:{1}:{2}. This usually happens "
+                                              "when you start Cuckoo without "
+                                              "bringing up the virtual interface "
+                                              "associated with the ResultServer "
+                                              "IP address. "
+                                              "See http://docs.cuckoosandbox.org"
+                                              "/en/latest/faq/#troubles-problem"
+                                              " for more information."
+                                              "".format(ip, self.port, str(e)))
                 else:
                     raise CuckooCriticalError("Unable to bind ResultServer on "
                                               "{0}:{1}: {2}".format(


### PR DESCRIPTION
This PR just adds handling for EADDRNOTAVAIL (Cannot assign requested address) when starting the ResultServer. The exception handling will tell the user the most common reason (interface associated with the server is not up)  for the exception and provides a link to the documentation. 

https://github.com/cuckoobox/cuckoo/issues/579