### PR TITLE
Functionality to initialize the environment for individual machinery

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -16,7 +16,6 @@ try:
     from lib.cuckoo.common.exceptions import CuckooDependencyError
     from lib.cuckoo.common.logo import logo
     from lib.cuckoo.common.utils import exception_message
-    from lib.cuckoo.core.resultserver import ResultServer
     from lib.cuckoo.core.scheduler import Scheduler
     from lib.cuckoo.core.startup import check_working_directory, check_configs
     from lib.cuckoo.core.startup import check_version, create_structure
@@ -77,7 +76,7 @@ def cuckoo_init(quiet=False, debug=False, artwork=False, test=False):
     if test:
         return
 
-    ResultServer()
+
 
     os.chdir(cur_path)
 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -83,10 +83,20 @@ class Machinery(object):
         """
         self.options = options
 
+    def _init_once(self):
+        """
+        Used to handle machinery specific initialization of the environment.
+        """
+        pass
+
     def initialize(self, module_name):
         """Read, load, and verify machines configuration.
         @param module_name: module name.
         """
+
+        #Initialize the environment if needed
+        self._init_once()
+
         # Load.
         self._initialize(module_name)
 

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -567,6 +567,9 @@ class Scheduler(object):
         except CuckooMachineError as e:
             raise CuckooCriticalError("Error initializing machines: %s" % e)
 
+        #Starting the ResultServer
+        ResultServer()
+
         # At this point all the available machines should have been identified
         # and added to the list. If none were found, Cuckoo needs to abort the
         # execution.


### PR DESCRIPTION
This PR provides a generic way to initialize the environment for different machineries. It creates a new function 'initialize_environment' in the abstract class Machinery. That function is called from cuckoo.py cuckoo_init(). This gives us a way to initialize the environment (interfaces, etc) before we try to start ResultServer.   

For the third (and possibly the final) time this refers to the task/issue: https://github.com/cuckoobox/cuckoo/issues/579
