### PR TITLE
Better granularity on summary log from NtCreateFile/NtOpenFile API

### DIFF
--- a/modules/processing/platform/windows.py
+++ b/modules/processing/platform/windows.py
@@ -197,7 +197,14 @@ class BehaviorReconstructor(object):
         self.files[arguments["file_handle"]] = arguments["filepath"]
         if NT_SUCCESS(return_value):
             status_info = flags["status_info"].lower()
-            return (status_info, arguments["filepath"])
+            if status_info in ("file_overwritten", "file_superseded"):
+                return ("file_recreated", arguments["filepath"])
+            elif status_info == "file_exists":
+                return ("file_opened", arguments["filepath"])
+            elif status_info == "file_does_not_exist":
+                return ("file_failed", arguments["filepath"])
+            else:
+                return ("file_opened", arguments["filepath"])
         else:
             return ("file_failed", arguments["filepath"])
 

--- a/modules/processing/platform/windows.py
+++ b/modules/processing/platform/windows.py
@@ -152,45 +152,45 @@ class BehaviorReconstructor(object):
         fn = getattr(self, "_api_%s" % event["api"], None)
         if fn is not None:
             if "flags" in event:
-                return fn(event["return_value"], event["arguments"], flags=event["flags"])
+                return fn(event["return_value"], event["arguments"], event["flags"])
             else:
-                return fn(event["return_value"], event["arguments"])
+                return fn(event["return_value"], event["arguments"], None)
 
     # Generic file & directory stuff.
 
-    def _api_CreateDirectoryW(self, return_value, arguments, flags=None):
+    def _api_CreateDirectoryW(self, return_value, arguments, flags):
         return ("directory_created", arguments["dirpath"])
 
     _api_CreateDirectoryExW = _api_CreateDirectoryW
 
-    def _api_RemoveDirectoryA(self, return_value, arguments, flags=None):
+    def _api_RemoveDirectoryA(self, return_value, arguments, flags):
         return ("directory_removed", arguments["dirpath"])
 
     _api_RemoveDirectoryW = _api_RemoveDirectoryA
 
-    def _api_MoveFileWithProgressW(self, return_value, arguments, flags=None):
+    def _api_MoveFileWithProgressW(self, return_value, arguments, flags):
         return ("file_moved", (arguments["oldfilepath"],
                                arguments["newfilepath"]))
 
-    def _api_CopyFileA(self, return_value, arguments, flags=None):
+    def _api_CopyFileA(self, return_value, arguments, flags):
         return ("file_copied", (arguments["oldfilepath"],
                                 arguments["newfilepath"]))
 
     _api_CopyFileW = _api_CopyFileA
     _api_CopyFileExW = _api_CopyFileA
 
-    def _api_DeleteFileA(self, return_value, arguments, flags=None):
+    def _api_DeleteFileA(self, return_value, arguments, flags):
         return ("file_deleted", arguments["filepath"])
 
     _api_DeleteFileW = _api_DeleteFileA
     _api_NtDeleteFile = _api_DeleteFileA
 
-    def _api_FindFirstFileExA(self, return_value, arguments, flags=None):
+    def _api_FindFirstFileExA(self, return_value, arguments, flags):
         return ("directory_enumerated", arguments["filepath"])
 
     _api_FindFirstFileExW = _api_FindFirstFileExA
 
-    def _api_LdrLoadDll(self, return_value, arguments, flags=None):
+    def _api_LdrLoadDll(self, return_value, arguments, flags):
         return ("dll_loaded", arguments["module_name"])
 
     def _api_NtCreateFile(self, return_value, arguments, flags):
@@ -203,31 +203,31 @@ class BehaviorReconstructor(object):
 
     _api_NtOpenFile = _api_NtCreateFile
 
-    def _api_NtReadFile(self, return_value, arguments, flags=None):
+    def _api_NtReadFile(self, return_value, arguments, flags):
         h = arguments["file_handle"]
         if NT_SUCCESS(return_value) and h in self.files:
             return ("file_read", self.files[h])
 
-    def _api_NtWriteFile(self, return_value, arguments, flags=None):
+    def _api_NtWriteFile(self, return_value, arguments, flags):
         h = arguments["file_handle"]
         if NT_SUCCESS(return_value) and h in self.files:
             return ("file_written", self.files[h])
 
-    def _api_GetFileAttributesW(self, return_value, arguments, flags=None):
+    def _api_GetFileAttributesW(self, return_value, arguments, flags):
         return ("file_exists", arguments["filepath"])
 
     _api_GetFileAttributesExW = _api_GetFileAttributesW
 
     # Registry stuff.
 
-    def _api_RegOpenKeyExA(self, return_value, arguments, flags=None):
+    def _api_RegOpenKeyExA(self, return_value, arguments, flags):
         return ("regkey_opened", arguments["regkey"])
 
     _api_RegOpenKeyExW = _api_RegOpenKeyExA
     _api_RegCreateKeyExA = _api_RegOpenKeyExA
     _api_RegCreateKeyExW = _api_RegOpenKeyExA
 
-    def _api_RegDeleteKeyA(self, return_value, arguments, flags=None):
+    def _api_RegDeleteKeyA(self, return_value, arguments, flags):
         return ("regkey_deleted", arguments["regkey"])
 
     _api_RegDeleteKeyW = _api_RegDeleteKeyA
@@ -235,41 +235,41 @@ class BehaviorReconstructor(object):
     _api_RegDeleteValueW = _api_RegDeleteKeyA
     _api_NtDeleteValueKey = _api_RegDeleteKeyA
 
-    def _api_RegQueryValueExA(self, return_value, arguments, flags=None):
+    def _api_RegQueryValueExA(self, return_value, arguments, flags):
         return ("regkey_read", arguments["regkey"])
 
     _api_RegQueryValueExW = _api_RegQueryValueExA
     _api_NtQueryValueKey = _api_RegQueryValueExA
 
-    def _api_RegSetValueExA(self, return_value, arguments, flags=None):
+    def _api_RegSetValueExA(self, return_value, arguments, flags):
         return ("regkey_written", arguments["regkey"])
 
     _api_RegSetValueExW = _api_RegSetValueExA
     _api_NtSetValueKey = _api_RegSetValueExA
 
-    def _api_NtClose(self, return_value, arguments, flags=None):
+    def _api_NtClose(self, return_value, arguments, flags):
         self.files.pop(arguments["handle"], None)
 
     # Network stuff.
 
-    def _api_URLDownloadToFileW(self, return_value, arguments, flags=None):
+    def _api_URLDownloadToFileW(self, return_value, arguments, flags):
         return [
             ("downloads_file", arguments["url"]),
             ("file_opened", arguments["filepath"]),
             ("file_written", arguments["filepath"]),
         ]
 
-    def _api_InternetConnectA(self, return_value, arguments, flags=None):
+    def _api_InternetConnectA(self, return_value, arguments, flags):
         return ("connects_host", arguments["hostname"])
 
     _api_InternetConnectW = _api_InternetConnectA
 
-    def _api_InternetOpenUrlA(self, return_value, arguments, flags=None):
+    def _api_InternetOpenUrlA(self, return_value, arguments, flags):
         return ("fetches_url", arguments["url"])
 
     _api_InternetOpenUrlW = _api_InternetOpenUrlA
 
-    def _api_DnsQuery_A(self, return_value, arguments, flags=None):
+    def _api_DnsQuery_A(self, return_value, arguments, flags):
         if arguments["hostname"]:
             return ("resolves_host", arguments["hostname"])
 
@@ -279,12 +279,12 @@ class BehaviorReconstructor(object):
     _api_GetAddrInfoW = _api_DnsQuery_A
     _api_gethostbyname = _api_DnsQuery_A
 
-    def _api_connect(self, return_value, arguments, flags=None):
+    def _api_connect(self, return_value, arguments, flags):
         return ("connects_ip", arguments["ip_address"])
 
     # Mutex stuff
 
-    def _api_NtCreateMutant(self, return_value, arguments, flags=None):
+    def _api_NtCreateMutant(self, return_value, arguments, flags):
         if arguments["mutant_name"]:
             return ("mutex", arguments["mutant_name"])
 
@@ -292,26 +292,26 @@ class BehaviorReconstructor(object):
 
     # Process stuff.
 
-    def _api_CreateProcessInternalW(self, return_value, arguments, flags=None):
+    def _api_CreateProcessInternalW(self, return_value, arguments, flags):
         cmdline = arguments["command_line"] or arguments["filepath"]
         return ("command_line", cmdline)
 
-    def _api_ShellExecuteExW(self, return_value, arguments, flags=None):
+    def _api_ShellExecuteExW(self, return_value, arguments, flags):
         if arguments["parameters"]:
             cmdline = "%s %s" % (arguments["filepath"], arguments["parameters"])
         else:
             cmdline = arguments["filepath"]
         return ("command_line", cmdline)
 
-    def _api_system(self, return_value, arguments, flags=None):
+    def _api_system(self, return_value, arguments, flags):
         return ("command_line", arguments["command"])
 
     # WMI stuff.
 
-    def _api_IWbemServices_ExecQuery(self, return_value, arguments, flags=None):
+    def _api_IWbemServices_ExecQuery(self, return_value, arguments, flags):
         return ("wmi_query", arguments["query"])
 
-    def _api_IWbemServices_ExecQueryAsync(self, return_value, arguments, flags=None):
+    def _api_IWbemServices_ExecQueryAsync(self, return_value, arguments, flags):
         return ("wmi_query", arguments["query"])
 
     # GUIDs.
@@ -322,7 +322,7 @@ class BehaviorReconstructor(object):
             ("guid", arguments["iid"]),
         ]
 
-    def _api_CoCreateInstanceEx(self, return_value, arguments, flags=None):
+    def _api_CoCreateInstanceEx(self, return_value, arguments, flags):
         ret = [
             ("guid", arguments["clsid"]),
         ]
@@ -330,7 +330,7 @@ class BehaviorReconstructor(object):
             ret.append(("guid", iid))
         return ret
 
-    def _api_CoGetClassObject(self, return_value, arguments, flags=None):
+    def _api_CoGetClassObject(self, return_value, arguments, flags):
         return [
             ("guid", arguments["clsid"]),
             ("guid", arguments["iid"]),
@@ -338,7 +338,7 @@ class BehaviorReconstructor(object):
 
     # SSLv3 & TLS Master Secrets.
 
-    def _api_Ssl3GenerateKeyMaterial(self, return_value, arguments, flags=None):
+    def _api_Ssl3GenerateKeyMaterial(self, return_value, arguments, flags):
         if arguments["client_random"] and arguments["server_random"]:
             return [
                 ("tls_master", (
@@ -348,7 +348,7 @@ class BehaviorReconstructor(object):
                 ))
             ]
 
-    def _api_PRF(self, return_value, arguments, flags=None):
+    def _api_PRF(self, return_value, arguments, flags):
         if arguments["type"] == "key expansion":
             return [
                 ("tls_master", (


### PR DESCRIPTION
/!\ This PR makes senses only with [PR #15 in monitor repo](https://github.com/cuckoobox/monitor/pull/15)
Summary log will be categorised according to status_info flag.
status_info is actually IoStatusBlock->Information arg from NtCreateFile/NtOpenFile
For details on IoStatusBlock arg, see [NtCreateFile doc](https://msdn.microsoft.com/en-us/library/bb432380%28v=vs.85%29.aspx)

So with this we actually know what happen precisely on files when NtCreateFile is called and probably we can know in which purpose the call has been used (just check file existence, open it, ...)