### PR TITLE
Update resultserver.py

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -140,9 +140,13 @@ class ResultHandler(SocketServer.BaseRequestHandler):
         while True:
             if self.end_request.isSet():
                 return False
-            rs, _, _ = select.select([self.request], [], [], 1)
-            if rs:
-                return True
+            #rs, _, _ = select.select([self.request], [], [], 1)
+            #if rs:
+            #   return True
+            events = epoll.poll(1)
+            for fd,event in events:
+                if event & select.EPOLLIN:
+                    return True
 
     def seek(self, pos):
         pass

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -137,6 +137,8 @@ class ResultHandler(SocketServer.BaseRequestHandler):
             self.rawlogfd.close()
 
     def wait_sock_or_end(self):
+        epoll = select.epoll()
+        epoll.register(self.request.fileno(),select.EPOLLIN)
         while True:
             if self.end_request.isSet():
                 return False


### PR DESCRIPTION
when run more than 25 vms ,cuckoo will be block，and the code cuckoo block also is select() function,so i think it will be so many request to handle,which due to the file that opened large than the max fd number and when use the epoll ,i had never miss this problem again