### PR TITLE
Import Yara Rules for YaraScan Recursively

### DIFF
--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -530,7 +530,7 @@ class VolatilityAPI(object):
 
         dirypath = '/'.join(fypath.split('/')[:-1])
 
-        tmpfile = '/'.join(fypath.split('/')[:-1]) +  '/.tmp_' + fypath.split('/')[-1]
+        tmpfile = dirypath +  '/.tmp_' + fypath.split('/')[-1]
         ff = open(tmpfile,'w')
         for root, dir, files in os.walk(dirypath):
             for filename in files:

--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -523,6 +523,26 @@ class VolatilityAPI(object):
         if not os.path.exists(ypath):
             return dict(config={}, data=[])
 
+        fypath = '"'.join(open(ypath,'r').read().split('"')[1:-1])
+
+        if not os.path.exists(fypath):
+            return dict(config={}, data=[])
+
+        dirypath = '/'.join(fypath.split('/')[:-1])
+
+        tmpfile = '/'.join(fypath.split('/')[:-1]) +  '/.tmp_' + fypath.split('/')[-1]
+        ff = open(tmpfile,'w')
+        for root, dir, files in os.walk(dirypath):
+            for filename in files:
+                if filename.startswith('.'): continue
+                filepath = os.path.join(root, filename)
+                if filepath in [fypath,tmpfile]: continue
+                ft = open(filepath,'r')
+                ff.write('\n' + ft.read())
+                ft.close()
+        ff.close()
+        os.rename(tmpfile,fypath)
+
         self.config.update("YARA_FILE", ypath)
 
         command = self.plugins["yarascan"](self.config)


### PR DESCRIPTION
[Issue 773](https://github.com/cuckoosandbox/cuckoo/issues/773)

For import _yarascan_ rules you have to edit the file `cuckoo/data/yara/memory/index_memory.yar` and insert all yara rules there.

It's tedious to copy all YARA rules to an unique file if you have your yara rules organized by directories.

So I propose to permit to insert your YARA rules directory at  `cuckoo/data/yara/memory/` and import all YARA rules that you can find recursively at this directory.

You could modify `cuckoo/data/yara/index_memory.yar`  and set an other path where you have all your YARA rules and it will import all of them.