### PR TITLE
Fix memory list issue

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -512,7 +512,7 @@ def memorydumps_list(task_id):
         if len(memory_files) == 0:
             return json_error(404, "Memory dump not found")
 
-        return jsonify(memory_files)
+        return jsonify({"dump_files": memory_files})
     else:
         return json_error(404, "Memory dump not found")
 


### PR DESCRIPTION
Jsonify doesn't work on plain arrays, without a key.
Getting 500 internal server error without this fix.