### PR TITLE
decoding to latin1 doesn't work for me, but this does

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -250,7 +250,7 @@ class CommandPipeHandler(object):
                 proc.inject(dll, apc=False, mode="%s" % mode)
 
             log.info("Injected into process with pid %s and name %s",
-                     proc.pid, filename.decode("latin-1"))
+                     proc.pid, filename.encode("utf-8"))
 
     def _handle_process(self, data):
         """Request for injection into a process."""


### PR DESCRIPTION
For some reason decoding to latin1 didn't make any difference, but when the string is encoded to UTF-8 then works. The string itself will look like garbage still, but at least it doesn't crash the process.
For example :
2016-02-27 15:32:14,750 [analyzer] INFO: Injected into process with pid 3044 and name 텀ȭ