### PR TITLE
Fix crash when suricata files dir doesn't exist

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -206,6 +206,14 @@ class Suricata(Processing):
 
         # Index all the available files.
         files_dir = os.path.join(self.suricata_path, self.files_dir)
+        # In case files dir doesn't exist then create it ... 
+        if not os.path.exists(files_dir):
+            log.debug("Creating Suricata files dir %s", files_dir)
+            log.warning("Maybe you forgot to enable Suricata file-store ?")
+            os.makedirs(files_dir)
+        else:
+            log.debug("Suricata files dir exist %s ...", files_dir)
+
         for filename in os.listdir(files_dir):
             filepath = os.path.join(files_dir, filename)
             files[md5_file(filepath)] = filepath

--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -206,13 +206,9 @@ class Suricata(Processing):
 
         # Index all the available files.
         files_dir = os.path.join(self.suricata_path, self.files_dir)
-        # In case files dir doesn't exist then create it ... 
         if not os.path.exists(files_dir):
-            log.debug("Creating Suricata files dir %s", files_dir)
-            log.warning("Maybe you forgot to enable Suricata file-store ?")
-            os.makedirs(files_dir)
-        else:
-            log.debug("Suricata files dir exist %s ...", files_dir)
+            log.warning("Suricata files dir is not available. Maybe you forgot to enable Suricata file-store ?")
+            return
 
         for filename in os.listdir(files_dir):
             filepath = os.path.join(files_dir, filename)


### PR DESCRIPTION
When suricata files dir doesn't exist (for example files-store is not enabled) then this leads to crash : 
`
suricata error : 
Traceback (most recent call last):
  File "/srv/cuckoo/lib/cuckoo/core/plugins.py", line 215, in process
    data = current.run()
  File "/srv/cuckoo/modules/processing/suricata.py", line 286, in run
    self.parse_files()
  File "/srv/cuckoo/modules/processing/suricata.py", line 209, in parse_files
    for filename in os.listdir(files_dir):
OSError: [Errno 2] No such file or directory: '/srv/cuckoo/storage/analyses/475/suricata/files'
`
