### PR TITLE
Drop Suricata privileges to enable Cuckoo to access them 

### DIFF
--- a/utils/suricata.sh
+++ b/utils/suricata.sh
@@ -14,6 +14,8 @@
 # * Set "unix-command.enabled" to "yes".
 # * Set "unix-command.filename" to "cuckoo.socket".
 # * Set "outputs.eve-log.enabled" to "yes".
+# * Set "run-as.user to "your cuckoo user"
+# * Set "run-as.group to "your cuckoo user group"
 # * TODO More items.
 #
 # Add "@reboot /opt/cuckoo/utils/suricata.sh" to the root crontab.
@@ -25,10 +27,11 @@ if [ "$SURICATA" -eq 0 ]; then
     exit
 fi
 
+mkdir /var/run/suricata
+chown cuckoo:cuckoo /var/run/suricata
+
 suricata --unix-socket -D
 
 while [ ! -e /var/run/suricata/cuckoo.socket ]; do
     sleep 1
 done
-
-sudo chown cuckoo:cuckoo /var/run/suricata/cuckoo.socket


### PR DESCRIPTION
As Suricata in socket mode is being run as root, files created is only accessible by root, Which makes Cuckoo not being able to read the content of the files create by Suricata.

This fix includes a description of what you need to change in the Suricata configuration file in order to make Suricata drop privileges to the set Cuckoo user.

The fix also enables the non root user to create the socket file in /var/run/suricata which is something that requires root privileges.