### PR TITLE
bugfix datetime serializer in jsondump.py

### DIFF
--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -16,7 +16,7 @@ def default(obj):
     if isinstance(obj, datetime.datetime):
         if obj.utcoffset() is not None:
             obj = obj - obj.utcoffset()
-        return calendar.timegm(obj.timetuple()) + obj.microsecond / 1000.0
+        return calendar.timegm(obj.timetuple()) + obj.microsecond / 1000000.0
     raise TypeError("%r is not JSON serializable" % obj)
 
 class JsonDump(Report):


### PR DESCRIPTION
The 'default' serializer in jsondump.py was adding microseconds/1000.0 to the timestamp. However, in order to get the milliseconds that are dropped by timetuple(), this should have been microseconds/1000000.0

See http://stackoverflow.com/a/26161653.

Cheers