### PR TITLE
Handle invalid symlinks when delete_bin_copy is specified.

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -49,6 +49,7 @@ class AnalysisManager(threading.Thread):
         self.cfg = Config()
         self.storage = ""
         self.binary = ""
+        self.storage_binary = ""
         self.machine = None
 
         self.db = Database()
@@ -115,12 +116,12 @@ class AnalysisManager(threading.Thread):
                 return False
 
         try:
-            new_binary_path = os.path.join(self.storage, "binary")
+            self.storage_binary = os.path.join(self.storage, "binary")
 
             if hasattr(os, "symlink"):
-                os.symlink(self.binary, new_binary_path)
+                os.symlink(self.binary, self.storage_binary)
             else:
-                shutil.copy(self.binary, new_binary_path)
+                shutil.copy(self.binary, self.storage_binary)
         except (AttributeError, OSError) as e:
             log.error("Unable to create symlink/copy from \"%s\" to "
                       "\"%s\": %s", self.binary, self.storage, e)
@@ -468,6 +469,12 @@ class AnalysisManager(threading.Thread):
                     os.remove(self.binary)
                 except OSError as e:
                     log.error("Unable to delete the copy of the original file at path \"%s\": %s", self.binary, e)
+            # Check if the binary in the analysis directory is an invalid symlink. If it is, delete it.
+            if os.path.islink(self.storage_binary) and not os.path.exists(self.storage_binary):
+                try:
+                    os.remove(self.storage_binary)
+                except OSError as e:
+                    log.error("Unable to delete symlink to the binary copy at path \"%s\": %s", self.storage_binary, e)
 
         log.info("Task #%d: reports generation completed (path=%s)",
                  self.task.id, self.storage)

--- a/utils/api.py
+++ b/utils/api.py
@@ -290,6 +290,8 @@ def tasks_report(task_id, report_format="json"):
         tar = tarfile.open(fileobj=s, mode=tarmode, dereference=True)
         for filedir in os.listdir(srcdir):
             filepath = os.path.join(srcdir, filedir)
+            if not os.path.exists(filepath):
+                continue
             if bzf["type"] == "-" and filedir not in bzf["files"]:
                 tar.add(filepath, arcname=filedir)
             if bzf["type"] == "+" and filedir in bzf["files"]:


### PR DESCRIPTION
This addresses issue #818 

When delete_bin_copy is specified, the binary in the report directory is checked to see if it is now an invalid symlink, and it's deleted if necessary. In the API, report files are checked for existence before being added to the tar (kind of double-checking here, since we are making sure to delete the invalid symlink).