### PR TITLE
Physical Machinery returning nonetype for guest status

### DIFF
--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -61,7 +61,7 @@ class OldGuestManager(object):
         self.server._set_timeout(self.timeout)
 
 #        while db.guest_get_status(self.task_id) == "starting":
-       while True:
+        while True:
             # Check if we've passed the timeout.
             if time.time() > end:
                 raise CuckooGuestError("{0}: the guest initialization hit the "

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -60,7 +60,8 @@ class OldGuestManager(object):
         end = time.time() + self.timeout
         self.server._set_timeout(self.timeout)
 
-        while db.guest_get_status(self.task_id) == "starting":
+#        while db.guest_get_status(self.task_id) == "starting":
+       while True:
             # Check if we've passed the timeout.
             if time.time() > end:
                 raise CuckooGuestError("{0}: the guest initialization hit the "


### PR DESCRIPTION
line 63 was breaking the get status for physical machine and returning nonetype to cuckoo.py in debug. copied this code from the 1.2 version of guest.py to fix my issue.
