### PR TITLE
Return a jsonified object when the report format is json

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -304,7 +304,12 @@ def tasks_report(task_id, report_format="json"):
         return json_error(400, "Invalid report format")
 
     if os.path.exists(report_path):
-        return open(report_path, "rb").read()
+        if report_format == "json":
+            response = make_response(open(report_path, "rb").read())
+            response.headers['Content-Type'] = 'application/json'
+            return response
+        else:
+            return open(report_path, "rb").read()
     else:
         return json_error(404, "Report not found")
 

--- a/utils/api.py
+++ b/utils/api.py
@@ -306,7 +306,7 @@ def tasks_report(task_id, report_format="json"):
     if os.path.exists(report_path):
         if report_format == "json":
             response = make_response(open(report_path, "rb").read())
-            response.headers['Content-Type'] = 'application/json'
+            response.headers["Content-Type"] = "application/json"
             return response
         else:
             return open(report_path, "rb").read()


### PR DESCRIPTION
When calling `GET /tasks/report` [1], the API does not return the proper content-type. This PR changes the content-type returned to `application/json`, rather than the default `text/html; charset=utf-8`.

[1] http://docs.cuckoosandbox.org/en/latest/usage/api/#tasks-report