### PR TITLE
Windows cmd title needs to be a quoted string

### DIFF
--- a/analyzer/windows/modules/packages/generic.py
+++ b/analyzer/windows/modules/packages/generic.py
@@ -18,7 +18,7 @@ class Generic(Package):
         cmd_path = self.get_path("cmd.exe")
 
         # Create random cmd.exe window title.
-        rand_title = random_string(4, 16)
+        rand_title = "\"{0}\"".format(random_string(4, 16))
 
         # START syntax.
         # See: https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/start.mspx?mfr=true


### PR DESCRIPTION
The title needs to be a quoted string. A breaking change was introduced in 4a90e0a893407569b42c417bb5c3b4c00f092cac when moving to list based arguments.