### PR TITLE
File type for JAR

### DIFF
--- a/lib/cuckoo/common/objects.py
+++ b/lib/cuckoo/common/objects.py
@@ -349,7 +349,7 @@ class File(object):
         """Get the entry point for this APK. The entry point is denoted by a
         package and main activity name."""
         filetype = self.get_type()
-        if "Zip archive data" not in filetype and "Java Jar" not in filetype:
+        if "Zip archive data" not in filetype and "Java archive data" not in filetype:
             return "", ""
 
         if not HAVE_ANDROGUARD:


### PR DESCRIPTION
The python magic module returns "Java archive data" for JAR file.

Tried on Mac and Linux(Debian, Archlinux).