### PR TITLE
Update wsgi.py

### DIFF
--- a/web/web/wsgi.py
+++ b/web/web/wsgi.py
@@ -19,6 +19,16 @@ framework.
 
 """
 import os
+import sys
+
+from os.path import join, dirname, abspath
+
+webdir = abspath(join(dirname(abspath(__file__)), '..'))
+sys.path.append(abspath(join(webdir, '..')))
+sys.path.append(webdir)
+
+from os import chdir,environ
+chdir(webdir)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "web.settings")
 


### PR DESCRIPTION
This gets rid of the missing web.settings error when you are trying to use the WSGI with Apache. Fix from older version/fork was here, still works for this:

https://github.com/spender-sandbox/cuckoo-modified/blob/master/web/web/wsgi.py