### PR TITLE
Update community.py

### DIFF
--- a/utils/community.py
+++ b/utils/community.py
@@ -77,7 +77,7 @@ def installdir(src, dst, force, rewrite, origin=[]):
             srcpath = os.path.join(src, file_name)
             if os.path.islink(srcpath):
                 if os.path.lexists(destination):
-                    os.remove(destination)
+                    shutil.rmtree(destination)
                 os.symlink(os.readlink(srcpath), destination)
                 print "Symbolic link \"%s/%s\" -> \"%s\" %s" % (
                     "/".join(origin), file_name, os.readlink(srcpath),


### PR DESCRIPTION
when running python community.py -awf, the current code leads to an exception, since os.remove expects an empty directory. 

Traceback (most recent call last):
  File "community.py", line 194, in <module>
    main()
  File "community.py", line 190, in main
    install(enabled, force, rewrite, args.archive)
  File "community.py", line 130, in install
    installdir(origin, os.path.join(CUCKOO_ROOT, folder), force, rewrite)
  File "community.py", line 80, in installdir
    os.remove(destination)
OSError: [Errno 21] Is a directory: '/home/user1/cuckoo/data/monitor/latest'

shutil.rmtree should be used to delete a directory with content in it. 

After making the change, the script completes correctly.



