### PR TITLE
Use shutil: os.remove is not for directories

### DIFF
--- a/utils/community.py
+++ b/utils/community.py
@@ -77,7 +77,7 @@ def installdir(src, dst, force, rewrite, origin=[]):
             srcpath = os.path.join(src, file_name)
             if os.path.islink(srcpath):
                 if os.path.lexists(destination):
-                    os.remove(destination)
+                    shutil.rmtree(destination)
                 os.symlink(os.readlink(srcpath), destination)
                 print "Symbolic link \"%s/%s\" -> \"%s\" %s" % (
                     "/".join(origin), file_name, os.readlink(srcpath),


### PR DESCRIPTION
os.remove raises OSError because "destination" is a directory. This error causes the rest of the community update to fail. This patch uses shutil.rmtree() which works fine. BTW: os.rmdir() will not work in this case because the directory is not empty.