### PR TITLE
inetsim and tor integration to rooter.py

### DIFF
--- a/analyzer/windows/modules/packages/doc.py
+++ b/analyzer/windows/modules/packages/doc.py
@@ -17,6 +17,7 @@ class DOC(Package):
         ("ProgramFiles", "Microsoft Office", "Office14", "WINWORD.EXE"),
         ("ProgramFiles", "Microsoft Office", "Office15", "WINWORD.EXE"),
         ("ProgramFiles", "Microsoft Office 15", "root", "office15", "WINWORD.EXE"),
+        ("ProgramFiles", "Microsoft Office", "root", "Office16", "WINWORD.EXE"),
         ("ProgramFiles", "Microsoft Office", "WORDVIEW.EXE"),
     ]
 
@@ -42,6 +43,15 @@ class DOC(Package):
                 # is not corrupted and is from trusted source before opening
                 # the file. Do you want to open the file now?"
                 "ExtensionHardening": 0,
+            },
+        ],
+        [
+            HKEY_CURRENT_USER,
+            "Software\\Microsoft\\Office\\16.0\\Word\\Security",
+            {
+                # Enable VBA macros in Office 2016.
+                "VBAWarnings": 1,
+                "AccessVBOM": 1,
             },
         ],
     ]

--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -103,7 +103,7 @@ auto_rt = yes
 
 # Inetsim
 inetsim = off
-inetsim_server = 192.168.2.179
+inetsim_server = inetsim_ip
 inetsim_interface = virbr0
 
 # Tor

--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -52,8 +52,8 @@ max_machines_count = 0
 # actual analysis. This option tries to avoid maxing out the CPU completely.
 max_vmstartup_count = 10
 
-# Minimum amount of free space (in MB) available before starting a new task. 
-# This tries to avoid failing an analysis because the reports can't be written 
+# Minimum amount of free space (in MB) available before starting a new task.
+# This tries to avoid failing an analysis because the reports can't be written
 # due out-of-diskspace errors. Setting this value to 0 disables the check.
 # (Note: this feature is currently not supported under Windows.)
 freespace = 64
@@ -91,15 +91,26 @@ internet = none
 # /etc/iproute2/rt_tables for existing names and IDs).
 rt_table = main
 
-# To route traffic through multiple network interfaces Cuckoo uses 
+# To route traffic through multiple network interfaces Cuckoo uses
 # Policy Routing with separate routing table for each output interface
-# (VPN or "dirty line"). If this option is enabled Cuckoo on start will try 
-# to automatically initialise routing tables by copying routing entries from 
-# main routing table to the new routing tables. Depending on your network/vpn 
-# configuration this might not be sufficient. In such case you would need to 
+# (VPN or "dirty line"). If this option is enabled Cuckoo on start will try
+# to automatically initialise routing tables by copying routing entries from
+# main routing table to the new routing tables. Depending on your network/vpn
+# configuration this might not be sufficient. In such case you would need to
 # initialise routing tables manually. Note that enabling this option won't
 # affect main routing table.
 auto_rt = yes
+
+# Inetsim
+inetsim = off
+inetsim_server = 192.168.2.179
+inetsim_interface = virbr0
+
+# Tor
+tor = off
+tor_dnsport = 5353
+tor_proxyport = 9040
+tor_interface = virbr0
 
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs

--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -1,4 +1,4 @@
-# Enable or disable the available processing modules [on/off].
+# Enable or disable the available processing modules [yes/no].
 # If you add a custom processing module to your Cuckoo setup, you have to add
 # a dedicated entry in this file, or it won't be executed.
 # You can also add additional options under the section of your module and

--- a/docs/book/src/customization/processing.rst
+++ b/docs/book/src/customization/processing.rst
@@ -22,7 +22,7 @@ example if you create a module *module/processing/foobar.py* you will have to ap
 the following section to *conf/processing.conf*::
 
     [foobar]
-    enabled = on
+    enabled = yes
 
 Every module will then be initialized and executed and the data returned
 will be appended in a data structure that we'll call **global container**.

--- a/lib/cuckoo/common/netlog.py
+++ b/lib/cuckoo/common/netlog.py
@@ -310,6 +310,7 @@ class BsonParser(ProtocolHandler):
 
                     # Is this process being "tracked"?
                     parsed["track"] = bool(argdict.get("track", 1))
+                    parsed["modules"] = argdict.get("modules", {})
 
                     self.pid = pid
 

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -220,7 +220,7 @@ class AnalysisManager(threading.Thread):
             self.rt_table = None
         elif self.route == "inetsim":
             self.interface = self.cfg.routing.inetsim_interface
-         elif self.route == "tor":
+        elif self.route == "tor":
             self.interface = self.cfg.routing.tor_interface
         elif self.route == "internet" and self.cfg.routing.internet != "none":
             self.interface = self.cfg.routing.internet

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -446,6 +446,45 @@ def init_routing():
             rooter("init_rttable", cuckoo.routing.rt_table,
                    cuckoo.routing.internet)
 
+    # Check if tor interface exists, if yes then enable nat
+    if cuckoo.routing.tor_interface:
+        if not rooter("nic_available", cuckoo.routing.tor_interface):
+            raise CuckooStartupError(
+                "The network interface that has been configured as tor "
+                "line is not available."
+            )
+
+        # Disable & enable NAT on this network interface. Disable it just
+        # in case we still had the same rule from a previous run.
+        rooter("disable_nat", cuckoo.routing.tor_interface)
+        rooter("enable_nat", cuckoo.routing.tor_interface)
+
+        # Populate routing table with entries from main routing table.
+        if cuckoo.routing.auto_rt:
+            rooter("flush_rttable", cuckoo.routing.rt_table)
+            rooter("init_rttable", cuckoo.routing.rt_table,
+                   cuckoo.routing.internet)
+
+
+    # Check if inetsim interface exists, if yes then enable nat, if interface is not the same as tor
+    if cuckoo.routing.inetsim_interface and cuckoo.routing.inetsim_interface !=  cuckoo.routing.tor_interface:
+        if not rooter("nic_available", cuckoo.routing.tor_interface):
+            raise CuckooStartupError(
+                "The network interface that has been configured as tor "
+                "line is not available."
+            )
+
+        # Disable & enable NAT on this network interface. Disable it just
+        # in case we still had the same rule from a previous run.
+        rooter("disable_nat", cuckoo.routing.tor_interface)
+        rooter("enable_nat", cuckoo.routing.tor_interface)
+
+        # Populate routing table with entries from main routing table.
+        if cuckoo.routing.auto_rt:
+            rooter("flush_rttable", cuckoo.routing.rt_table)
+            rooter("init_rttable", cuckoo.routing.rt_table,
+                   cuckoo.routing.internet)
+
 def cuckoo_clean():
     """Clean up cuckoo setup.
     It deletes logs, all stored data from file system and configured

--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -80,6 +80,8 @@ def render_index(request, kwargs={}):
         "vpns": vpns.values(),
         "route": cfg.routing.route,
         "internet": cfg.routing.internet,
+        "inetsim": cfg.routing.inetsim,
+        "tor": cfg.routing.tor,
     }
 
     values.update(kwargs)

--- a/web/templates/submission/index.html
+++ b/web/templates/submission/index.html
@@ -103,6 +103,12 @@ $(document).ready( function() {
                     <div class="panel-body">
                         <select class="form-control" id="form_route" name="route">
                             <option value="none">None (no internet access)</option>
+                            {% if inetsim %}
+                                <option value="inetsim">inetsim</option>
+                            {% endif %}
+                            {% if tor %}
+                                <option value="tor">tor</option>
+                            {% endif %}
                             {% if internet != "none" %}
                                 <option value="internet"{% if route == "internet" %} selected{% endif %}>Internet (dirty line, {{ internet }})</option>
                             {% endif %}


### PR DESCRIPTION
### inetsim

```
wget https://googledrive.com/host/0B6fULLT_NpxMQ1Rrb1drdW42SkE/remnux-6.0-ova-public.ova
tar xvf remnux-6.0-ova-public.ova
qemu-img convert -O qcow2 REMnuxV6-disk1.vmdk remnux.qcow2 # or convert to your format
# set permament ip and configure it in conf
```

### tor
```
To install Tor, follow the guide option 2, not option 1, [here](https://www.torproject.org/docs/debian.html.en)

Once Tor is installed, edit its configuration file

$ sudo nano /etc/tor/torrc
Add the following lines to the bottom:

TransListenAddress 192.168.56.1
TransPort 9040
DNSListenAddress 192.168.56.1
DNSPort 5353
Note: 192.168.56.1 is the default address for the first VirtualBox host-only adaptor (vboxnet0). Adjust as necessary for your virtualization setup to match Cuckoo's result server IP address.

Then restart Tor:

$ sudo service tor restart
$ sudo uupdate-rc.d tor defautls
```