### PR TITLE
cryptography pkg fix on arch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.8.0
 beautifulsoup4==4.4.1
 cffi==1.2.1
 chardet==2.3.0
-cryptography==1.0
+cryptography==1.2.3
 Django==1.8.4
 dpkt==1.8.6.2
 ecdsa==0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 alembic==0.8.0
 beautifulsoup4==4.4.1
-cffi==1.2.1
+cffi==1.6.0
 chardet==2.3.0
-cryptography==1.2.3
+cryptography==1.3.2
 Django==1.8.4
 dpkt==1.8.6.2
 ecdsa==0.13


### PR DESCRIPTION
upgrade cryptography to 1.2.3.
This allow to install all the requirements on arch linux and may fix  issue  #889 too on Ubuntu 16.04

Error : 

`gcc -pthread -fno-strict-aliasing -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -DNDEBUG -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_openssl.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_openssl.o
  build/temp.linux-x86_64-2.7/_openssl.c:687:6: error: conflicting types for ‘BIO_new_mem_buf’
   BIO *BIO_new_mem_buf(void *, int);
        ^~~~~~~~~~~~~~~
  In file included from /usr/include/openssl/asn1.h:65:0,
                   from build/temp.linux-x86_64-2.7/_openssl.c:403:
  /usr/include/openssl/bio.h:692:6: note: previous declaration of ‘BIO_new_mem_buf’ was here
   BIO *BIO_new_mem_buf(const void *buf, int len);
        ^~~~~~~~~~~~~~~
  build/temp.linux-x86_64-2.7/_openssl.c:2063:15: error: ‘SSLv2_method’ redeclared as different kind of symbol
   SSL_METHOD* (*SSLv2_method)(void) = NULL;`

