### PR TITLE
Allow environment variables to be used in config files.

### DIFF
--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -18,7 +18,7 @@ class Config:
         @param file_name: file name without extension.
         @param cfg: configuration file path.
         """
-        config = ConfigParser.ConfigParser()
+        config = ConfigParser.ConfigParser(os.environ)
 
         if cfg:
             config.read(cfg)


### PR DESCRIPTION
This is necessary so parameters can be injected into the config file from the environment, e.g. if you're deploying with Docker, or using good devops practices in general.

```
[database]
connection = postgresql://cuckoo:%(CUCKOO_PG_PASS)s@%(CUCKOO_PG_HOST)s:5432/%(CUCKOO_PG_DB)s

# or ...

connection = %(CUCKOO_PG_DSN)s
```