### PR TITLE
Fixes & improvements to distributed Cuckoo

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -115,7 +115,7 @@ class Files(object):
 
     def dump_files(self):
         """Dump all pending files."""
-        for filepath in self.files:
+        for filepath in list(self.files):
             self.dump_file(filepath)
 
 class ProcessList(object):

--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -65,6 +65,9 @@ tmppath = /tmp
 # Path to the unix socket for running root commands.
 rooter = /tmp/cuckoo-rooter
 
+# Path for client-side sockets used to connect to rooter
+rooter_tmp = /tmp/
+
 [routing]
 # Default network routing mode; "none", "internet", or "vpn_name".
 # In none mode we don't do any special routing - the VM doesn't have any

--- a/distributed/instance.py
+++ b/distributed/instance.py
@@ -89,8 +89,9 @@ def handle_all_nodes_loop():
                 break
             except Exception:
                 log.exception("Failure handling node %s", node.name)
-        delay = min(time.time() - start, 0)
-        if delay:
+        duration = max(0, time.time() - start)
+        delay = settings.interval - duration
+        if delay > 0:
             time.sleep(delay)
 
 
@@ -189,7 +190,7 @@ def handle_node(instance=None, node=None):
 
         t.status = Task.FINISHED
         t.started = datetime.datetime.strptime(task["started_on"],
-                                               "%Y-%m-%d %H:%M:%S")
+                                               "%Y%m%dT%H:%M:%S")
         t.completed = datetime.datetime.now()
 
     log.debug("Fetched %d reports from %s", len(tasks), node.name)

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -320,7 +320,10 @@ class Task(Base):
         d = Dictionary()
         for column in self.__table__.columns:
             value = getattr(self, column.name)
-            d[column.name] = value
+            if isinstance(value, datetime):
+                d[column.name] = value.strftime("%Y%m%dT%H:%M:%S")
+            else:
+                d[column.name] = value
 
         # Tags are a relation so no column to iterate.
         d["tags"] = [tag.name for tag in self.tags]

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -14,7 +14,8 @@ from lib.cuckoo.common.config import Config
 
 cfg = Config()
 log = logging.getLogger(__name__)
-unixpath = tempfile.mktemp()
+unixpath = tempfile.mktemp(dir=cfg.cuckoo.rooter_tmp
+                               if cfg.cuckoo.rooter_tmp else None)
 lock = threading.Lock()
 
 vpns = {}

--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -40,6 +40,7 @@ def rooter(command, *args, **kwargs):
     except socket.error as e:
         log.critical("Unable to passthrough root command as we're unable to "
                      "connect to the rooter unix socket: %s.", e)
+        lock.release()
         return
 
     s.send(json.dumps({

--- a/utils/machine.py
+++ b/utils/machine.py
@@ -25,7 +25,7 @@ def update_conf(machinery, args, action=None):
         if "=" in line and line.split("=")[0].strip() == "machines":
             # Parse all existing labels.
             labels = line.split("=", 1)[1]
-            labels = [label.strip() for label in labels.split(",")]
+            labels = filter(None, [label.strip() for label in labels.split(",")])
 
             if action == "add":
                 labels.append(args.vmname)


### PR DESCRIPTION
This includes fixes and improvements to distributed cuckoo, notably:

 * Gracefully handle empty `machine=` in config
 * Re-sync instance machines when worker is re-enabled
 * Don't require separate process per cuckoo instance
 * Datetime parsing between dist & cuckoo API

These changes are required for my docker-ized Cuckoo to operate smoothly, but should be useful for everybody.

`instance.py` accepts a new parameter: `dist.handler` - this polls all enabled instances, avoiding the need to run one instance.py per worker, or updating the config when new workers are added or removed.