### PR TITLE
Bugfixes

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -600,15 +600,15 @@ class Analyzer(object):
                 aux.start()
             except (NotImplementedError, AttributeError):
                 log.warning("Auxiliary module %s was not implemented",
-                            aux.__class__.__name__)
+                            module.__name__)
             except CuckooDisableModule:
                 continue
             except Exception as e:
                 log.warning("Cannot execute auxiliary module %s: %s",
-                            aux.__class__.__name__, e)
+                            module.__name__, e)
             else:
                 log.debug("Started auxiliary module %s",
-                          aux.__class__.__name__)
+                          module.__name__)
                 aux_enabled.append(aux)
 
         # Start analysis package. If for any reason, the execution of the

--- a/analyzer/windows/lib/common/results.py
+++ b/analyzer/windows/lib/common/results.py
@@ -66,9 +66,9 @@ class NetlogConnection(object):
                 self.connect()
                 self.send(data, retry=False)
             else:
-                print >>sys.stderr, "Unhandled exception in NetlogConnection: %s", str(e)
+                print >>sys.stderr, "Unhandled exception in NetlogConnection: %s" % str(e)
         except Exception as e:
-            print >>sys.stderr, "Unhandled exception in NetlogConnection: %s", str(e)
+            print >>sys.stderr, "Unhandled exception in NetlogConnection: %s" % str(e)
             # We really have nowhere to log this, if the netlog connection
             # does not work, we can assume that any logging won't work either.
             # So we just fail silently.

--- a/lib/cuckoo/core/guest.py
+++ b/lib/cuckoo/core/guest.py
@@ -278,12 +278,18 @@ class GuestManager(object):
     def get(self, method, *args, **kwargs):
         """Simple wrapper around requests.get()."""
         url = "http://%s:%s%s" % (self.ipaddr, self.port, method)
-        return requests.get(url, *args, **kwargs)
+        session = requests.Session()
+        session.trust_env = False
+        session.proxies = None
+        return session.get(url, *args, **kwargs)
 
     def post(self, method, *args, **kwargs):
         """Simple wrapper around requests.post()."""
         url = "http://%s:%s%s" % (self.ipaddr, self.port, method)
-        return requests.post(url, *args, **kwargs)
+        session = requests.Session()
+        session.trust_env = False
+        session.proxies = None
+        return session.post(url, *args, **kwargs)
 
     def wait_available(self):
         """Wait until the Virtual Machine is available for usage."""

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -69,8 +69,8 @@ def enable_nat(interface):
 
 def disable_nat(interface):
     """Disable NAT on this interface."""
-    run(settings.iptables, "-t", "nat", "-D", "POSTROUTING",
-        "-o", interface, "-j", "MASQUERADE")
+    while not run(settings.iptables, "-t", "nat", "-D", "POSTROUTING",
+        "-o", interface, "-j", "MASQUERADE")[1]: pass
 
 def init_rttable(rt_table, interface):
     """Initialise routing table for this interface using routes


### PR DESCRIPTION
This commit fixes 4 bugs:

- rooter.py: The iptables command allows adding the same rule multiple times, this fix modifies the disable_nat function in rooter.py to clean up all the iptables rules (ensuring that it will be actually disabled, and not only the first rule will be removed).

- analyzer.py: Due to a minor bug in the code whenever there is a problem with the auxiliary module Cuckoo will report the *previous* module's name and not the one that it was actually trying to load.

- guest.py: If the HTTP_PROXY/HTTPS_PROXY environment variables are set, the requests module will try to use them, and this is not desirable when trying to connect to a guest machine - this workaround disables the local proxy for agent connections.

- results.py: A simple formatting bug.