### PR TITLE
Analyze .jse

### DIFF
--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -61,7 +61,7 @@ def choose_package(file_type, file_name, exports):
         return "python"
     elif file_name.endswith(".vbs"):
         return "vbs"
-    elif file_name.endswith(".js"):
+    elif file_name.endswith((".js", ".jse")):
         return "js"
     elif file_name.endswith(".msi"):
         return "msi"


### PR DESCRIPTION
This adds .jse
.jse is actively used by many currently active malware families (e.g. Cerber) to download/drop the payload.
