### PR TITLE
Adding a check so the analysis don't get stuck when cuckoo has no permissions to access target file

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -83,7 +83,14 @@ class AnalysisManager(threading.Thread):
             return False
 
         return True
-
+        
+    def check_permissions(self):
+        """Checks if we have permissions to access the file to be analyzed."""
+        if os.access(self.task.target, os.R_OK):
+            return True
+        log.error("Unable to access target file, please check if we have permissions to access the file: \"%s\"", self.task.target)
+        return False    
+                
     def check_file(self):
         """Checks the integrity of the file to be analyzed."""
         sample = self.db.view_sample(self.task.sample_id)
@@ -319,6 +326,11 @@ class AnalysisManager(threading.Thread):
         self.store_task_info()
 
         if self.task.category == "file":
+            # Check if we have permissions to access the file.
+            # And fail this analysis if we don't have access to the file.
+            if not self.check_permissions():
+                return False
+                
             # Check whether the file has been changed for some unknown reason.
             # And fail this analysis if it has been modified.
             if not self.check_file():


### PR DESCRIPTION
What happens before this commit:
user "normaluser" does 
`/opt/cuckoo/utils/submit.py --options route=proxy0 /tmp/evil.js`

and cuckoo runs as user "cuckoo"

And the following behavior happens:

```
2016-07-07 20:52:09,893 [lib.cuckoo.core.scheduler] INFO: Starting analysis of FILE "evil.js" (task #84, options "route=proxy0")
2016-07-07 20:52:09,899 [lib.cuckoo.core.scheduler] ERROR: Failure in AnalysisManager.run
Traceback (most recent call last):
  File "/opt/cuckoo/lib/cuckoo/core/scheduler.py", line 502, in run
    self.launch_analysis()
  File "/opt/cuckoo/lib/cuckoo/core/scheduler.py", line 324, in launch_analysis
    if not self.check_file():
  File "/opt/cuckoo/lib/cuckoo/core/scheduler.py", line 91, in check_file
    sha256 = File(self.task.target).get_sha256()
  File "/opt/cuckoo/lib/cuckoo/common/objects.py", line 208, in get_sha256
    self.calc_hashes()
  File "/opt/cuckoo/lib/cuckoo/common/objects.py", line 153, in calc_hashes
    for chunk in self.get_chunks():
  File "/opt/cuckoo/lib/cuckoo/common/objects.py", line 138, in get_chunks
    with open(self.file_path, "rb") as fd:
IOError: [Errno 13] Permission denied: u'/tmp/evil.js'
```
And the analysis is stuck forever (until you restart cuckoo.)
This commit will fix this and it will tell the user what happened.