### PR TITLE
Linux guest: Add a delay when falling back to strace

### DIFF
--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -74,19 +74,26 @@ class STAP(Auxiliary):
         strace_start = time.time()
 
         # wait completion of strace attachment; it may take a bit of time
+        traced_fn = "strace/straced.%u" % os.getpid()
         while True:
-            try:
-                if os.path.getsize("strace/straced.%u" % os.getpid()) > 0:
-                    break
-                time.sleep(1)
+            time.sleep(1)
 
-            except: # file is not yet there
-                if (time.time() - strace_start) > 10:
-                    # timeout; something wrong
-                    log.info("STAP aux module timed out to run strace.")
-                    break
+            if (time.time() - strace_start) > 10:
+                # timeout; something wrong
+                log.info("STAP aux module timed out to run strace.")
+                break
 
+            if not os.path.exists(traced_fn):
+                # file has not been generated yet
                 continue
+
+            try:
+                if os.path.getsize(traced_fn) > 0: break
+
+            except Exception as e: 
+                # something wrong
+                log.warning(e)
+
 
         return True
 

--- a/analyzer/linux/modules/auxiliary/stap.py
+++ b/analyzer/linux/modules/auxiliary/stap.py
@@ -68,9 +68,14 @@ class STAP(Auxiliary):
         try: os.mkdir("strace")
         except: pass # don't worry, it exists
 
+        strace_start = time.time()
         stderrfd = open("strace/strace.stderr", "wb")
         self.proc = subprocess.Popen(["strace", "-ff", "-o", "strace/straced", "-p", str(os.getpid())], stderr=stderrfd)
         self.fallback_strace = True
+
+        time.sleep(10)
+        strace_end = time.time()
+        log.info("STAP aux module startup took %.2f seconds" % (strace_end - strace_start))
         return True
 
     def get_pids(self):


### PR DESCRIPTION
It was needed for strace to catch sample execution correctly.
