### PR TITLE
Fix missing dependencies

### DIFF
--- a/docs/book/src/installation/host/requirements.rst
+++ b/docs/book/src/installation/host/requirements.rst
@@ -14,7 +14,7 @@ preferred.
 
 Install the basic dependencies::
 
-    $ sudo apt-get install python python-pip python-dev libffi-dev libssl-dev
+    $ sudo apt-get install python python-pip python-dev libffi-dev libssl-dev libjpeg-dev libxml2-dev libxslt1-dev
 
 If you want to use the Django-based web interface, you'll have to install
 MongoDB too::


### PR DESCRIPTION
You should install libjpeg-dev or disable jpeg for Pillow package
Ref: https://github.com/python-pillow/Pillow/issues/1457

libxml2-dev libxslt1-dev are dependencies for lxml package
Ref: http://lxml.de/installation.html
