### PR TITLE
Added /exit call for debugging purposes and automated closing

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -32,6 +32,15 @@ def json_error(status_code, message):
     r.status_code = status_code
     return r
 
+def shutdown_server():
+    """Shutdown API werkzeug server"""
+    shutdown = request.environ.get("werkzeug.server.shutdown")
+    if shutdown:
+        shutdown()
+        return True
+    else:
+        return False
+
 @app.after_request
 def custom_headers(response):
     """Set some custom headers across all HTTP responses."""
@@ -548,6 +557,19 @@ def vpn_status():
         return json_error(500, "Rooter not available")
 
     return jsonify({"vpns": status})
+
+@app.route("/exit")
+def exit_api():
+    """Shuts down the server if in debug mode and
+    using the werkzeug server"""
+    if app.debug:
+        if not shutdown_server():
+            return json_error(500, "Shutdown only possible if using werkzeug"
+                                   " server")
+        else:
+            return jsonify(message="Server stopped")
+    else:
+        return json_error(403, "This call can only be used in debug mode")
 
 def cuckoo_api(hostname, port, debug):
     app.run(host=hostname, port=port, debug=debug)


### PR DESCRIPTION
This call can be used in to gracefully close the API server. This can be useful when doing automated testing.