### PR TITLE
Cuckoo integration with Mattermost

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -70,12 +70,15 @@ enabled = no
 #
 # Username to show when posting message
 username=cuckoo
-# What kind of data to show apart from default. 0 disables and 1 enables.
+# What kind of data to show apart from default.
 # Show virustotal hits.
-# show-virustotal=1
+# show-virustotal=yes
 # 
 # Show matched cuckoo signatures.
-# show-signatures=0
+# show-signatures=no
 #
 # Show collected URL-s by signature "network_http".
-# show-urls=1
+# show-urls=no
+# 
+# Hide filename and create hash of it
+# hash-filename=no 

--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -56,3 +56,12 @@ enabled = no
 # moloch_capture = /data/moloch/bin/moloch-capture
 # conf = /data/moloch/etc/config.ini
 # instance = cuckoo
+
+[mattermost]
+enabled = no
+
+# Mattermost webhook URL
+# url=
+#
+# Cuckoo host URL to make analysis ID clickable
+# myurl=

--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -60,8 +60,20 @@ enabled = no
 [mattermost]
 enabled = no
 
-# Mattermost webhook URL
+# Mattermost webhook URL.
+# example : https://my.mattermost.host/hooks/yourveryrandomkey
 # url=
 #
-# Cuckoo host URL to make analysis ID clickable
+# Cuckoo host URL to make analysis ID clickable.
+# example : https://my.cuckoo.host/
 # myurl=
+#
+# What kind of data to show apart from default. 0 disables and 1 enables.
+# Show virustotal hits.
+# show-virustotal=1
+# 
+# Show matched cuckoo signatures.
+# show-signatures=0
+#
+# Show collected URL-s by signature "network_http".
+# show-urls=1

--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -68,6 +68,8 @@ enabled = no
 # example : https://my.cuckoo.host/
 # myurl=
 #
+# Username to show when posting message
+username=cuckoo
 # What kind of data to show apart from default. 0 disables and 1 enables.
 # Show virustotal hits.
 # show-virustotal=1

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -22,19 +22,29 @@ class Mattermost(Report):
                 for http in sig.get("marks"):
                     urls.append(http.get("ioc"))
 
+        post = "Finished analyze ::: [{0}]({1}{0}) ::: ".format(
+                            results.get("info").get("id"),
+                            self.options.get("myurl")
+                            )
+
+        post += "File : {0} ::: ".format(
+                            results.get("target").get("file").get("name")
+                            )
+
+        if self.options.get("show-virustotal"):
+            post += "**VT : {0} / {1}**\n".format(
+                            results.get("virustotal").get("total"),
+                            results.get("virustotal").get("positives"),
+                            )
+
+        if self.options.get("show-signatures"):
+            post += "**Signatures** ::: {0} \n".format(' : '.join(sigs),)
+
+        if self.options.get("show-urls"):
+            post += "**URLS**\n`{0}`".format('\n'.join(urls).replace(".", "[.]"))
+
         data = {
-            "text": "Finished analyze ::: [{0}]({4}{0}) ::: "
-                    "File : {1} ::: "
-                    "VT : {2} / {3} \n "
-                    "SIGS ::: {5} \n "
-                    "**URLS**\n `{6}`".format(
-                        results.get("info").get("id"), 
-                        results.get("target").get("file").get("name"), 
-                        results.get("virustotal").get("total"), 
-                        results.get("virustotal").get("positives"), 
-                        self.options.get("myurl"), 
-                        ' : '.join(sigs), '\n'.join(urls).replace(".", "[.]")
-                    ) 
+            "text": post
         }
 
         headers = {'Content-Type': 'application/json'}

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2010-2013 Claudio Guarnieri.
+# Copyright (C) 2014-2016 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+import json
+import requests
+
+from lib.cuckoo.common.abstracts import Report
+from lib.cuckoo.common.exceptions import CuckooReportError
+
+class Mattermost(Report):
+    """Notifies about finished analysis via Mattermost webhook."""
+
+    def run(self, results):
+
+        sigs = []
+        urls = []
+        for sig in results.get("signatures", {}):
+            sigs.append(sig.get("name"))
+            if sig.get("name") == "network_http":
+                for http in sig.get("marks"):
+                    urls.append(http.get("ioc"))
+
+        data = {
+            "text": "Finished analyze ::: [{0}]({4}{0}) ::: "
+                    "File : {1} ::: "
+                    "VT : {2} / {3} \n "
+                    "SIGS ::: {5} \n "
+                    "**URLS**\n `{6}`".format(
+                        results.get("info").get("id"), 
+                        results.get("target").get("file").get("name"), 
+                        results.get("virustotal").get("total"), 
+                        results.get("virustotal").get("positives"), 
+                        self.options.get("myurl"), 
+                        ' : '.join(sigs), '\n'.join(urls).replace(".", "[.]")
+                    ) 
+        }
+
+        headers = {'Content-Type': 'application/json'}
+        response = requests.post(self.options.get("url"), headers=headers, data=json.dumps(data))

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -46,8 +46,8 @@ class Mattermost(Report):
 
         if self.options.get("show-virustotal"):
             post += "**VT : {0} / {1}**\n".format(
-                            results.get("virustotal").get("total"),
                             results.get("virustotal").get("positives"),
+                            results.get("virustotal").get("total"),
                             )
 
         if self.options.get("show-signatures"):

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -4,6 +4,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import json
+import hashlib
 
 try:
     import requests
@@ -39,8 +40,13 @@ class Mattermost(Report):
                             self.options.get("myurl")
                             )
 
+        filename = results.get("target").get("file").get("name")
+        if self.options.get("hash-filename"):
+            filename = hashlib.sha256(filename).hexdigest()
+            
+
         post += "File : {0} ::: Score : **{1}** ::: ".format(
-                            results.get("target").get("file").get("name"),
+                            filename,
                             results.get("info").get("score")
                             )
 

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -14,6 +14,7 @@ except ImportError:
  
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.exceptions import CuckooReportError
+from lib.cuckoo.common.exceptions import CuckooOperationalError
 
 class Mattermost(Report):
     """Notifies about finished analysis via Mattermost webhook."""

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -21,7 +21,6 @@ class Mattermost(Report):
     """Notifies about finished analysis via Mattermost webhook."""
 
     def run(self, results):
-
         if not HAVE_REQUESTS:
             raise CuckooOperationalError(
                 "The Mattermost processing module requires the requests "
@@ -36,9 +35,9 @@ class Mattermost(Report):
                     urls.append(http.get("ioc"))
 
         post = "Finished analyze ::: [{0}]({1}{0}) ::: ".format(
-                            results.get("info").get("id"),
-                            self.options.get("myurl")
-                            )
+            results.get("info").get("id"),
+            self.options.get("myurl")
+        )
 
         filename = results.get("target").get("file").get("name")
         if self.options.get("hash-filename"):
@@ -46,21 +45,23 @@ class Mattermost(Report):
             
 
         post += "File : {0} ::: Score : **{1}** ::: ".format(
-                            filename,
-                            results.get("info").get("score")
-                            )
+            filename,
+            results.get("info").get("score")
+        )
 
         if self.options.get("show-virustotal"):
             post += "**VT : {0} / {1}**\n".format(
-                            results.get("virustotal").get("positives"),
-                            results.get("virustotal").get("total"),
-                            )
+                results.get("virustotal").get("positives"),
+                results.get("virustotal").get("total"),
+            )
 
         if self.options.get("show-signatures"):
-            post += "**Signatures** ::: {0} \n".format(' : '.join(sigs),)
+            post += "**Signatures** ::: {0} \n".format(' : '.join(sigs))
 
         if self.options.get("show-urls"):
-            post += "**URLS**\n`{0}`".format('\n'.join(urls).replace(".", "[.]"))
+            post += "**URLS**\n`{0}`".format(
+                '\n'.join(urls).replace(".", "[.]")
+            )
 
         data = {
             "username": self.options.get("username"),
@@ -70,6 +71,12 @@ class Mattermost(Report):
         headers = {'Content-Type': 'application/json'}
         
         try:
-            requests.post(self.options.get("url"), headers=headers, data=json.dumps(data))
+            requests.post(
+                self.options.get("url"), 
+                headers=headers, 
+                data=json.dumps(data)
+            )
         except Exception as e:
-            raise CuckooReportError("Failed posting message to Mattermost: %s" % e)
+            raise CuckooReportError(
+                    "Failed posting message to Mattermost: %s" % e
+            )

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -44,6 +44,7 @@ class Mattermost(Report):
             post += "**URLS**\n`{0}`".format('\n'.join(urls).replace(".", "[.]"))
 
         data = {
+            "username": self.options.get("username"),
             "text": post
         }
 

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -22,7 +22,7 @@ class Mattermost(Report):
 
         if not HAVE_REQUESTS:
             raise CuckooOperationalError(
-                "The IRMA processing module requires the requests "
+                "The Mattermost processing module requires the requests "
                 "library (install with `pip install requests`)")
 
         sigs = []

--- a/modules/reporting/mattermost.py
+++ b/modules/reporting/mattermost.py
@@ -27,8 +27,9 @@ class Mattermost(Report):
                             self.options.get("myurl")
                             )
 
-        post += "File : {0} ::: ".format(
-                            results.get("target").get("file").get("name")
+        post += "File : {0} ::: Score : **{1}** ::: ".format(
+                            results.get("target").get("file").get("name"),
+                            results.get("info").get("score")
                             )
 
         if self.options.get("show-virustotal"):


### PR DESCRIPTION
This reporting module pushes notification to Mattermost about finished analysis via webhook. Probably will work also with other slack type setups via webhook however I don't have one at hand for testing

By default it prints to the channel :
`Finished analyze ::: 7 ::: File : ksdauy9.exe ::: Score : 5.4 :::` 

However it's possible to enable vt output , signatures and URL-s matched via signature. So the eventual output can become like :
`Finished analyze ::: 27518 ::: File : ScanX4262X.docm ::: Score : 5.4 ::: VT : 56 / 33  
Signatures ::: antivm_queries_computername : recon_fingerprint : raises_exception : dumped_buffer : network_http : allocates_rwx : antisandbox_sleep : creates_doc : creates_exe : suspicious_process : persistence_ads : dexter : exploit_heapspray : modifies_desktop_wallpaper : office_write_exe : dead_host : antivirus_virustotal : modifies_files 
 URLS
 GET http://digiwebstore[.]fr/4GBrdf6
POST http://185[.]129[.]148[.]19/php/upload[.]php`