### PR TITLE
very basic notification plugin for Reporting 

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -56,3 +56,16 @@ enabled = no
 # moloch_capture = /data/moloch/bin/moloch-capture
 # conf = /data/moloch/etc/config.ini
 # instance = cuckoo
+
+[notification]
+# Notification module to inform external systems that analysis is finished.
+# You should consider keeping this as very last reporting module.
+enabled = no
+
+# External service URL where info will be POSTed.
+# example : https://my.example.host/some/destination/url
+# url=
+#
+# Cuckoo host identifier - can be hostname.
+# for example : my.cuckoo.host
+# identifier=

--- a/modules/reporting/notification.py
+++ b/modules/reporting/notification.py
@@ -32,19 +32,20 @@ class Notification(Report):
         if not HAVE_REQUESTS:
             raise CuckooOperationalError(
                 "The Notification reporting module requires the requests "
-                "library (install with `pip install requests`)")
+                "library (install with `pip install requests`)"
+            )
         
         post = {
-                "identifier" : self.options.get("identifier"),
-                "data" : json.dumps(results.get("info"), default=default, sort_keys=False)
-                }
+            "identifier" : self.options.get("identifier"),
+            "data" : json.dumps(results.get("info"), default=default, sort_keys=False)
+        }
 
         try:
             requests.post(
-                          self.options.get("url"), 
-                          data=post
-                        )
+                 self.options.get("url"), 
+                 data=post
+            )
         except Exception as e:
             raise CuckooReportError(
-                        "Failed posting message via Notification : %s" % e
-                        )
+                "Failed posting message via Notification : %s" % e
+            )

--- a/modules/reporting/notification.py
+++ b/modules/reporting/notification.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2014-2016 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+import json
+import datetime
+import calendar
+
+try:
+    import requests
+    HAVE_REQUESTS = True
+
+except ImportError:
+     HAVE_REQUESTS = False
+
+from lib.cuckoo.common.abstracts import Report
+from lib.cuckoo.common.exceptions import CuckooReportError
+from lib.cuckoo.common.exceptions import CuckooOperationalError
+
+def default(obj):
+    if isinstance(obj, datetime.datetime):
+        if obj.utcoffset() is not None:
+            obj = obj - obj.utcoffset()
+        return calendar.timegm(obj.timetuple()) + obj.microsecond / 1000000.0
+    raise TypeError("%r is not JSON serializable" % obj)
+
+class Notification(Report):
+    """Notifies external service about finished analysis via URL."""
+
+    def run(self, results):
+
+        if not HAVE_REQUESTS:
+            raise CuckooOperationalError(
+                "The Notification reporting module requires the requests "
+                "library (install with `pip install requests`)")
+        
+        post = {
+                "identifier" : self.options.get("identifier"),
+                "data" : json.dumps(results.get("info"), default=default, sort_keys=False)
+                }
+
+        try:
+            requests.post(
+                          self.options.get("url"), 
+                          data=post
+                        )
+        except Exception as e:
+            raise CuckooReportError(
+                        "Failed posting message via Notification : %s" % e
+                        )


### PR DESCRIPTION
In order to have external applications or scripts to collect analysis data timely it's quite costly (or even useless) to have them poking API all the time to figure out if the task has been finished or not. On the same time collecting the information from databases or other methods also doesn't work well as some analysis take more time than others and you have to keep track of their states - depending on configuration of course.

This PR basically provides a simple way to have one application/script to feed tasks from one end and this one will notifiy from other end to make something useful with the result :) It passes down `results.info` in json as `data` and the host `identifier` so that notification receiver would know to which host from the cluster reported it. Having the module to POST more data doesn't make much sense as all of it can be grabbed via other methods when suitable. However it can be made configurable in case it makes sense.

@jbremer not sure but maybe it makes sense to abstract `def default(obj):` as it's used here the same way as in jsondump (https://github.com/cuckoosandbox/cuckoo/blob/master/modules/reporting/jsondump.py#L15-L20)