### PR TITLE
Using SetLocalTime instead of SetSystemTime

### DIFF
--- a/analyzer/windows/lib/core/startup.py
+++ b/analyzer/windows/lib/core/startup.py
@@ -33,4 +33,4 @@ def set_clock(clock):
     st.wMinute = clock.minute
     st.wSecond = clock.second
     st.wMilliseconds = 0
-    KERNEL32.SetSystemTime(ctypes.byref(st))
+    KERNEL32.SetLocalTime(ctypes.byref(st))


### PR DESCRIPTION
As described in [https://github.com/cuckoosandbox/cuckoo/issues/1067](url), the time is misinterpreted by windows when SetSystemTime is  being used.