### PR TITLE
Change default value of the clock attribute wihtin DB to None

### DIFF
--- a/analyzer/windows/analyzer.py
+++ b/analyzer/windows/analyzer.py
@@ -448,9 +448,10 @@ class Analyzer(object):
         Process.set_config(self.config)
 
         # Set virtual machine clock.
-        set_clock(datetime.datetime.strptime(
-            self.config.clock, "%Y%m%dT%H:%M:%S"
-        ))
+	if self.config.clock:
+		set_clock(datetime.datetime.strptime(
+		    self.config.clock, "%Y%m%dT%H:%M:%S"
+		))
 
         # Set the default DLL to be used for this analysis.
         self.default_dll = self.config.options.get("dll")

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -278,9 +278,7 @@ class Task(Base):
     platform = Column(String(255), nullable=True)
     memory = Column(Boolean, nullable=False, default=False)
     enforce_timeout = Column(Boolean, nullable=False, default=False)
-    clock = Column(DateTime(timezone=False),
-                   default=datetime.now,
-                   nullable=False)
+    clock = Column(DateTime(timezone=False), nullable=True)
     added_on = Column(DateTime(timezone=False),
                       default=datetime.now,
                       nullable=False)

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -208,8 +208,13 @@ class AnalysisManager(threading.Thread):
         options["package"] = self.task.package
         options["options"] = emit_options(self.task.options)
         options["enforce_timeout"] = self.task.enforce_timeout
-        options["clock"] = self.task.clock
+        
         options["terminate_processes"] = self.cfg.cuckoo.terminate_processes
+
+	if self.task.clock:	
+		options["clock"] = self.task.clock
+	else:
+		options["clock"]= False
 
         if not self.task.timeout:
             options["timeout"] = self.cfg.timeouts.default


### PR DESCRIPTION
As described in #1071 I would do the following change. Please take a look whether the change complies with the requirements. 

Also I am quiet sure that the linux analyzer should also be changed from 
"if self.config.get("clock", None):" to "if self.config.clock:"

Please review!

Thx