### PR TITLE
Elasticsearch additional items

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -41,7 +41,11 @@ calls = no
 # valid options: yearly, monthly, daily
 #
 # index_time_pattern = yearly
-
+#
+# Cuckoo node name in Elasticsearch to identify reporting host. Can be useful
+# for automation and while referring back to correct Cuckoo host. 
+#
+# cuckoo_node = "cuckoo.example.host"
 
 [moloch]
 enabled = no

--- a/modules/reporting/elasticsearch.py
+++ b/modules/reporting/elasticsearch.py
@@ -198,9 +198,13 @@ class ElasticSearch(Report):
         # Index target information, the behavioral summary, and
         # VirusTotal results.
         self.do_index({
+            "cuckoo_node": self.options.get("cuckoo_node"), 
             "target": results.get("target"),
             "summary": results.get("behavior", {}).get("summary"),
             "virustotal": results.get("virustotal"),
+            "irma": results.get("irma"),
+            "signatures": results.get("signatures"),
+            "dropped": results.get("dropped"),
         })
 
         # Index the API calls.


### PR DESCRIPTION
Hi,

this PR adds more items to Elasticsearch index : 
* configurable cuckoo_node var so it's possible to know which cuckoo host report belongs to
* irma results
* signatures results
* dropped results

Cheers