### PR TITLE
I made the following changes to be able to successfully analyse andro…

### DIFF
--- a/analyzer/android/lib/api/adb.py
+++ b/analyzer/android/lib/api/adb.py
@@ -23,14 +23,19 @@ def install_sample(path):
 
     log.info("Installed sample: %r", output)
 
-def execute_sample(package, activity):
+def execute_sample(package):
     """Execute the sample on the emulator via adb"""
     try:
-        package_activity = "%s/%s" % (package, activity)
-        args = [
-            "/system/bin/sh", "/system/bin/am", "start",
-            "-n", package_activity,
+                args = [
+	    "/system/bin/sh",
+            "/system/bin/monkey",
+	    "-p", 
+	    "%s" % package,
+	    "-c",
+            "android.intent.category.LAUNCHER",
+	    "1",
         ]
+
         output = subprocess.check_output(args)
     except subprocess.CalledProcessError as e:
         log.error("Error executing package activity: %r", e)

--- a/analyzer/android/modules/packages/apk.py
+++ b/analyzer/android/modules/packages/apk.py
@@ -19,7 +19,7 @@ class Apk(Package):
 
     def start(self, path):
         install_sample(path)
-        execute_sample(self.package, self.activity)
+        execute_sample(self.package)
 
     def check(self):
         return True

--- a/modules/machinery/avd.py
+++ b/modules/machinery/avd.py
@@ -72,7 +72,7 @@ class Avd(Machinery):
         """
         log.debug("Starting vm %s" % label)
 
-        self.duplicate_reference_machine(label)
+        #self.duplicate_reference_machine(label)
         self.start_emulator(label, task)
         self.port_forward(label)
         self.start_agent(label)
@@ -177,8 +177,8 @@ class Avd(Machinery):
         ]
 
         # In headless mode we remove the skin, audio, and window support.
-        if self.options.avd.mode == "headless":
-            cmd += ["-no-skin", "-no-audio", "-no-window"]
+#        if self.options.avd.mode == "headless":
+#            cmd += ["-no-skin", "-no-audio", "-no-window"]
 
         # If a proxy address has been provided for this analysis, then we have
         # to pass the proxy address along to the emulator command. The


### PR DESCRIPTION
…id apps:

I have made changes to avd.py so that it does not create a copy of original AVD.
it runs the same AVD provided by refrence_machine var. this will allow us to
run the AVD from snapshot. I also disabled the headless mode because in my
experince AVD cannot be run from snapshot in headless mode.
the reason to run AVD from snapshot is that if you root an AVD and restart it,
superuser app failes to give superuser access to app(although the su binary
is in place and given the excutable permission). to fix this problem you have
to do the rooting process all over.but since running AVD from snapshot does
not go through boot process, we won't have that problem.

I have also made changes to lib/cuckoo/common/objects.py. I tried to analyse
some apk files. get_apk_entry was not able to find the package name and the
name of the MainActivity of most of the apps I tried to analyse.
I installed apktool and made get_apk_entry use this tool. apktool extracts
an apk file and I read the AndroidManifest.xml file. AndroidManifest.xml
contains the name of the package.this works for all apk files.

I also made changes to adb.py. I changed execute_sample function. this way
you don't need to know the name of the MainActivity.

other changes was made as a result of the changes I just described.