### PR TITLE
Add restart functionality for physical emulation

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -174,6 +174,15 @@ class Agent(object):
         self.current_status = STATUS_RUNNING
         return self.analyzer_pid
 
+    def restart(self):
+        """ Restart the machine (for physical machine analysis). 
+        """
+        try:
+            subprocess.call(["shutdown","-r"])
+            return True
+        except: 
+            return False
+        
     def complete(self, success=True, error="", results=""):
         """Complete analysis.
         @param success: success status.


### PR DESCRIPTION
When conducting emulation with the physical machinery, the physical guest machine 
has to be rebooted prior to subsequent analyses. This is currently done by issuing an 
RPC to the Windows RPC server, which is sent via the SMB protocol. At times, there are 
some underlying issues in SMB that prevent the RPC to be executed in the intended manner, 
and as a result the machine doesn't reboot, leaving it in an unclean state for further analysis. 
This can be over come by adding the option of rebooting via Cuckoo agent's XML-RPC server
by registering the aforementioned functionality as a procedure on the server. An additional 
change is also made to physical.py to accomplish this.