### PR TITLE
a bit more improved publisher package

### DIFF
--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -40,7 +40,7 @@ class PUB(Package):
             HKEY_CURRENT_USER,
             "Software\\Microsoft\\Office\\15.0\\Publisher\\Security",
             {
-                # Enable VBA macros in Office 2007.
+                # Enable VBA macros in Office 2013.
                 "VBAWarnings": 1,
                 "AccessVBOM": 1,
 

--- a/analyzer/windows/modules/packages/pub.py
+++ b/analyzer/windows/modules/packages/pub.py
@@ -65,5 +65,5 @@ class PUB(Package):
     def start(self, path):
         publisher = self.get_path("Microsoft Office Publisher")
         return self.execute(
-            publisher, args=[path], mode="office", trigger="file:%s" % path
+            publisher, args=["/o", path], mode="office", trigger="file:%s" % path
         )


### PR DESCRIPTION
https://support.office.com/en-us/article/Command-line-switches-for-Publisher-2007-f9ba86d1-7d44-45a9-80ac-41cb158361df

/o filename

Starts Publisher and opens an existing file.
Example    To open a file, type the following at the command prompt:

/o filename

NOTE: The filename variable can identify the file by the path to the file, by a URL, or by the file path to the Windows Explorer shortcut (*.LNK) to the file or URL. If the file name has spaces in it, enclose the complete name in quotation marks. For example, /t "Contoso Business Card.pub"