### PR TITLE
Fix agent.py timeout error caused by tcpdump process.

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -88,7 +88,7 @@ class Sniffer(Auxiliary):
 
         try:
             self.proc = subprocess.Popen(
-                pargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                pargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
             )
         except (OSError, ValueError):
             log.exception(


### PR DESCRIPTION
When I ran cuckoo, encountered many time out error:

```
2016-09-20 14:04:27,790 [lib.cuckoo.core.guest] DEBUG: vm-117: error retrieving status: timed out
2016-09-20 14:04:28,799 [lib.cuckoo.core.scheduler] ERROR: The analysis hit the critical timeout, terminating.
```

```
2016-09-20 14:08:58,540 [lib.cuckoo.core.scheduler] ERROR: vm-111: the guest initialization hit the critical timeout, analysis aborted.
```
Finally I found it's caused by tcpdump process, which inherits parent process's opened connections:

```
tcp      259      0 192.168.56.1:44116            192.168.56.106:8000           CLOSE_WAIT  24558/tcpdump       
tcp        0      0 192.168.56.1:50038            192.168.56.113:8000           ESTABLISHED 24356/tcpdump
```

Set `closed_fds` to`Ture`, cuckoo works well.