### PR TITLE
Use named temp file for create/file in API

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -84,7 +84,7 @@ def tasks_create_file():
     if unique and db.find_sample(sha256=hashlib.sha256(content).hexdigest()):
         return json_error(400, "This file has already been submitted")
 
-    temp_file_path = Files.temp_put(content, data.filename)
+    temp_file_path = Files.temp_named_put(content, data.filename)
 
     task_id = db.add_path(
         file_path=temp_file_path,


### PR DESCRIPTION
This PR changes the file util method used to store a analysis binary if it is submitted through the API.
The recent change to Files.temp_put introduced the unwanted behavior of an analysis binary being created at wherever a Cuckoo instance was started from, instead of it being created in cuckoo_tmp.

Changing the used method to store the analysis binaries resolves this issue.