### PR TITLE
fix LATEST_HTTPREPLAY warning in webgui

### DIFF
--- a/lib/cuckoo/common/constants.py
+++ b/lib/cuckoo/common/constants.py
@@ -17,4 +17,4 @@ CUCKOO_GUEST_FAILED = 0x004
 GITHUB_URL = "https://github.com/cuckoosandbox/cuckoo"
 ISSUES_PAGE_URL = "https://github.com/cuckoosandbox/cuckoo/issues"
 
-LATEST_HTTPREPLAY = "0.1.11"
+LATEST_HTTPREPLAY = "0.1.15"


### PR DESCRIPTION
>>> import httpreplay
>>> getattr(httpreplay, "__version__", None)
'0.1.15'