### PR TITLE
Fix errror "AnalysisManager has no attribute route."

### DIFF
--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -60,6 +60,7 @@ class AnalysisManager(threading.Thread):
         self.task = self.db.view_task(task_id)
         self.guest_manager = None
 
+        self.route = None
         self.interface = None
         self.rt_table = None
 


### PR DESCRIPTION
self.unroute_network() may cause error "AnalysisManager has no attribute route." if self.route_network() doesn't run.