### PR TITLE
LibVirt machinery should create the KVM domain

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -405,7 +405,7 @@ class LibVirtMachinery(Machinery):
             self._disconnect(conn)
             raise CuckooMachineError("No snapshot found for virtual machine "
                                      "{0}".format(label))
-
+        self.vms[label].create()
         # Check state.
         self._wait_status(label, self.RUNNING)
 


### PR DESCRIPTION
Currently, LibVirt machinery can determine the snapshot and revert
the VM state to it, but it jumps straight to waiting for a state
change without actually issuing a create call to the domain being
used.

Add a single line to call self.vms[label].create() after resolving
the snapshot state and prior to entering the wait state.