### PR TITLE
Elasticsearch 5.0 client library compatibility and bug fixes

### DIFF
--- a/data/elasticsearch/template.json
+++ b/data/elasticsearch/template.json
@@ -12,7 +12,49 @@
         "cuckoo": {
             "dynamic_templates": [
                 {
-                    "notanalyzed": {
+                    "not_analyzed": {
+                        "mapping": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
+                        "match_mapping_type": "string",
+                        "match": "*"
+                    }
+                },
+                {
+                    "signatures": {
+                        "mapping": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
+                        "path_match": "signatures.marks.call.arguments.*",
+                        "path_unmatch": "signatures.marks.call.arguments.registers.*",
+                        "match": "*",
+                        "match_mapping_type": "long"
+                    }
+                }
+            ],
+            "properties": {
+                "report_time": {
+                    "format": "epoch_second",
+                    "type": "date"
+                },
+                "procmemory": {
+                    "type": "nested",
+                    "include_in_root": "True",
+                    "properties": {
+                        "regions": {
+                           "include_in_root": "True",
+                           "type": "nested"
+                        }
+                    }
+                }
+            }
+        },
+        "call": {
+            "dynamic_templates": [
+                {
+                    "not_analyzed": {
                         "mapping": {
                             "index": "not_analyzed",
                             "type": "string",
@@ -21,26 +63,16 @@
                         "match_mapping_type": "string",
                         "match": "*"
                     }
-                }
-            ],
-            "properties": {
-                "report_time": {
-                    "format": "epoch_second",
-                    "type": "date"
-                }
-            }
-        },
-        "call": {
-            "dynamic_templates": [
+                },
                 {
-                    "notanalyzed": {
+                    "call_arguments": {
                         "mapping": {
                             "index": "not_analyzed",
-                            "type": "string",
-                            "doc_values": "True"
+                            "type": "string"
                         },
-                        "match_mapping_type": "string",
-                        "match": "*"
+                        "path_match": "arguments.*",
+                        "match": "*",
+                        "match_mapping_type": "long"
                     }
                 }
             ],

--- a/data/elasticsearch/template.json
+++ b/data/elasticsearch/template.json
@@ -1,5 +1,4 @@
 {
-    "order": 0,
     "template": "cuckoo-*",
     "settings": {
         "index": {
@@ -11,6 +10,7 @@
     },
     "mappings": {
         "cuckoo": {
+            "date_detection": false,
             "dynamic_templates": [
                 {
                     "not_analyzed": {
@@ -27,7 +27,8 @@
                     "signatures": {
                         "mapping": {
                             "index": "not_analyzed",
-                            "type": "string"
+                            "type": "string",
+                            "ignore_above": 32766
                         },
                         "path_match": "signatures.marks.call.arguments.*",
                         "path_unmatch": "signatures.marks.call.arguments.registers.*",
@@ -54,13 +55,14 @@
             }
         },
         "call": {
+            "date_detection": false,
             "dynamic_templates": [
                 {
                     "not_analyzed": {
                         "mapping": {
                             "index": "not_analyzed",
                             "type": "string",
-                            "doc_values": "True"
+                            "ignore_above": 32766
                         },
                         "match_mapping_type": "string",
                         "match": "*"
@@ -70,7 +72,8 @@
                     "call_arguments": {
                         "mapping": {
                             "index": "not_analyzed",
-                            "type": "string"
+                            "type": "string",
+                            "ignore_above": 32766
                         },
                         "path_match": "arguments.*",
                         "match": "*",
@@ -85,6 +88,5 @@
                 }
             }
         }
-    },
-    "aliases": {}
+    }
 }

--- a/data/elasticsearch/template.json
+++ b/data/elasticsearch/template.json
@@ -16,7 +16,8 @@
                     "not_analyzed": {
                         "mapping": {
                             "index": "not_analyzed",
-                            "type": "string"
+                            "type": "string",
+                            "ignore_above": 32766
                         },
                         "match_mapping_type": "string",
                         "match": "*"

--- a/data/elasticsearch/template.json
+++ b/data/elasticsearch/template.json
@@ -3,6 +3,7 @@
     "template": "cuckoo-*",
     "settings": {
         "index": {
+            "mapping.coerce": true,
             "number_of_shards": "1",
             "codec": "best_compression",
             "number_of_replicas": "0"

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -509,7 +509,7 @@ def cuckoo_clean():
                 # also drop the dynamic template
                 es.indices.delete_template(cuckoo_template)
         except:
-            log.warning("Unable to drop ElasticSearch database: %s", index)
+            log.warning("Unable to drop ElasticSearch database %s", cuckoo_index)
 
     # Paths to clean.
     paths = [

--- a/modules/reporting/elasticsearch.py
+++ b/modules/reporting/elasticsearch.py
@@ -107,9 +107,11 @@ class ElasticSearch(Report):
             # template.json.
             cuckoo_template["template"] = self.index + "-*"
 
-        self.es.indices.put_template(
-            name=self.template_name, body=json.dumps(cuckoo_template)
-        )
+        # if the template does not already exist then create it
+        if self.es.indices.exists_template(self.template_name):
+            self.es.indices.put_template(
+                name=self.template_name, body=json.dumps(cuckoo_template)
+            )
         return True
 
     def get_base_document(self):

--- a/modules/reporting/elasticsearch.py
+++ b/modules/reporting/elasticsearch.py
@@ -14,7 +14,6 @@ from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.exceptions import CuckooDependencyError
 from lib.cuckoo.common.exceptions import CuckooReportError
-from lib.cuckoo.common.utils import convert_to_printable
 
 logging.getLogger("elasticsearch").setLevel(logging.WARNING)
 logging.getLogger("elasticsearch.trace").setLevel(logging.WARNING)
@@ -93,7 +92,7 @@ class ElasticSearch(Report):
         if not os.path.exists(template_path):
             return False
 
-        with open(template_path, "rw") as f:
+        with open(template_path, "r") as f:
             try:
                 cuckoo_template = json.loads(f.read())
             except ValueError:

--- a/modules/reporting/elasticsearch.py
+++ b/modules/reporting/elasticsearch.py
@@ -194,7 +194,6 @@ class ElasticSearch(Report):
                 call_document.update(call)
                 call_document.update(base_document)
                 bulk_index.append({
-                    "_op_type": "index",
                     "_index": self.dated_index,
                     "_type": self.call_type,
                     "_source": call_document

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cryptography==1.3.2
 Django==1.8.4
 dpkt==1.8.7
 ecdsa==0.13
-elasticsearch==2.2.0
+elasticsearch==5.0.1
 enum34==1.0.4
 Flask==0.10.1
 HTTPReplay==0.1.17


### PR DESCRIPTION
Compatibility with Elasticsearch 5.0.1 python module. This has also been tested with ES 2.x and ES 5.x.

Fixes bugs: https://github.com/cuckoosandbox/cuckoo/issues/1178 https://github.com/cuckoosandbox/cuckoo/issues/1183

Turned date detection off in the field mapping. This solves an issue that @keithjjones was having where yara rules had a valid date in a meta attribute that was getting automatically parsed by Elasticsearch as a date field. The default behavior now is to turn off date detection except when explicitly stated in the elasticsearch json.

This also incorporates PR #1120 as well as dropping the cuckoo template with the cuckoo indexes.

Fixed signatures which sometimes had a key value structure where a value was sometimes a object (dictionary) and sometimes a string. Now dictionaries are explicitly named _dict.

Also cleaned up parts of the elasticsearch reporting module code. Due to the new elasticsearch mapping for calls we do not need the process_call function anymore as it will be taken care of by the mapping.

ES 5.0 server fix was to change es.create to es.index as now you need to specify a id if you are issuing a create in ES 5.0.

Increased timeout to index documents from the default 10 seconds to 5 minutes. This can also be changed with a "hidden" timeout option in the reporting.conf file.

Many many thanks to @keithjjones who worked with me to find the yara date detection bug!