### PR TITLE
Some pathes

### DIFF
--- a/conf/qemu.conf
+++ b/conf/qemu.conf
@@ -37,7 +37,7 @@ interface = qemubr
 
 # (Optional) Specify the IP of the Result Server, as your virtual machine sees it.
 # The Result Server will always bind to the address and port specified in cuckoo.conf,
-# however you could set up your virtual network to use NAT/PAT, so you can specify here 
+# however you could set up your virtual network to use NAT/PAT, so you can specify here
 # the IP address for the Result Server as your machine sees it. If you don't specify an
 # address here, the machine will use the default value from cuckoo.conf.
 # NOTE: if you set this option you have to set result server IP to 0.0.0.0 in cuckoo.conf.
@@ -56,12 +56,25 @@ resultserver_ip = 192.168.55.1
 # specific VMs. You can run samples on VMs with tag you require.
 tags = debian_wheezy,64_bit
 
+# example of mips vm
 [vm2]
 label = vm2
 image = /home/rep/vms/qvm_wheezy64_1.qcow2
 arch = mipsel
-kernel_path = {imagepath}/vmlinux-3.16.0-4-4kc-malta-mipsel
+kernel = {imagepath}/vmlinux-3.16.0-4-4kc-malta-mipsel
 platform = linux
 ip = 192.168.55.3
 interface = qemubr
 tags = debian_wheezy,mipsel
+
+# example of arm vm
+[vm3]
+label = vm3
+image = /home/rep/vms/qvm_wheezy64_2.qcow2
+arch = mipsel
+kernel = {imagepath}/vmlinuz-3.2.0-4-versatile-arm
+initrd = {imagepath}/initrd-3.2.0-4-versatile-arm
+platform = linux
+ip = 192.168.55.4
+interface = qemubr
+tags = debian_wheezy,arm

--- a/conf/qemu.conf
+++ b/conf/qemu.conf
@@ -71,7 +71,7 @@ tags = debian_wheezy,mipsel
 [vm3]
 label = vm3
 image = /home/rep/vms/qvm_wheezy64_2.qcow2
-arch = mipsel
+arch = arm
 kernel = {imagepath}/vmlinuz-3.2.0-4-versatile-arm
 initrd = {imagepath}/initrd-3.2.0-4-versatile-arm
 platform = linux

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -52,7 +52,7 @@ class AnalysisManager(threading.Thread):
         self.binary = ""
         self.storage_binary = ""
         self.machine = None
-
+        self.route = None
         self.db = Database()
         self.task = self.db.view_task(task_id)
         self.guest_manager = None


### PR DESCRIPTION
* add `self.route` value to init, as if vm is in an incorrect state, scheduler.py calls unroute_network and it trigger error as self.route not defined and it generates “Failure in AnalysisManager.run”

* QEMU config patch, emu machinery looks for `kernel`, not
`kernel_path`, + added example of arm vm as that one requires `initrd` value

* documentation how to setup them will be in next PR

@jbremer the same persist in package, can you backport it or want me do PR to package?