### PR TITLE
Ignore empty strings in machines definition

### DIFF
--- a/utils/machine.py
+++ b/utils/machine.py
@@ -26,6 +26,8 @@ def update_conf(machinery, args, action=None):
             # Parse all existing labels.
             labels = line.split("=", 1)[1]
             labels = [label.strip() for label in labels.split(",")]
+            if '' in labels:
+                labels.remove('')
 
             if action == "add":
                 labels.append(args.vmname)


### PR DESCRIPTION
If only "machines = " is defined and machines are added e.g. by vmcloak later, this prevents adding a machine named '' (empty string)

This prevents the following error line when starting up:

    2017-02-02 12:22:54,919 [lib.cuckoo.common.abstracts] WARNING: Configuration details about machine  are missing: Option  is not found in configuration, error: Config instance has no attribute ''