### PR TITLE
Fix KVM sniffing and Debian Testing compatibility  

### DIFF
--- a/conf/kvm.conf
+++ b/conf/kvm.conf
@@ -15,7 +15,7 @@ interface = virbr0
 label = cuckoo1
 
 # Specify the operating system platform used by current machine
-# [windows/darwin/linux].
+# [windows/darwin/linux]
 platform = windows
 
 # Specify the IP address of the current virtual machine. Make sure that the

--- a/conf/kvm.conf
+++ b/conf/kvm.conf
@@ -29,11 +29,6 @@ ip = 192.168.122.105
 # Example (Snapshot1 is the snapshot name):
 # snapshot = Snapshot1
 
-# (Optional) Specify the name of the network interface that should be used
-# when dumping network traffic from this machine with tcpdump.
-# Example (virbr0 is the interface name):
-# interface = virbr0
-
 # (Optional) Specify the IP of the Result Server, as your virtual machine sees it.
 # The Result Server will always bind to the address and port specified in cuckoo.conf,
 # however you could set up your virtual network to use NAT/PAT, so you can specify here 

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -37,6 +37,7 @@ class Auxiliary(object):
         self.machine = None
         self.guest_manager = None
         self.options = None
+        self.db = Database()
 
     def set_task(self, task):
         self.task = task

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -537,6 +537,23 @@ class Database(object):
             session.close()
 
     @classlock
+    def set_machine_interface(self, label, interface):
+        session = self.Session()
+        try:
+            machine = session.query(Machine).filter_by(label=label).first()
+            if machine is None:
+                log.debug("Database error setting interface: {0} not found".format(label))
+                return None
+            machine.interface = interface
+            session.commit()
+
+        except SQLAlchemyError as e:
+            log.debug("Database error setting interface: {0}".format(e))
+            session.rollback()
+        finally:
+            session.close()
+
+    @classlock
     def set_status(self, task_id, status):
         """Set task status.
         @param task_id: task identifier

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -541,12 +541,12 @@ class Database(object):
         session = self.Session()
         try:
             machine = session.query(Machine).filter_by(label=label).first()
+
             if machine is None:
                 log.debug("Database error setting interface: {0} not found".format(label))
                 return None
             machine.interface = interface
             session.commit()
-
         except SQLAlchemyError as e:
             log.debug("Database error setting interface: {0}".format(e))
             session.rollback()

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -33,6 +33,7 @@ latest_symlink_lock = threading.Lock()
 
 active_analysis_count = 0
 
+
 class AnalysisManager(threading.Thread):
     """Analysis Manager.
 
@@ -43,7 +44,7 @@ class AnalysisManager(threading.Thread):
     """
 
     def __init__(self, task_id, error_queue):
-        """@param task: task object containing the details for the analysis."""
+        """@param task_id: task object containing the details for the analysis."""
         threading.Thread.__init__(self)
 
         self.errors = error_queue
@@ -366,9 +367,6 @@ class AnalysisManager(threading.Thread):
             self.machine.platform, self.task.id, self
         )
 
-        self.aux = RunAuxiliary(self.task, self.machine, self.guest_manager)
-        self.aux.start()
-
         # Generate the analysis configuration file.
         options = self.build_options()
 
@@ -386,6 +384,10 @@ class AnalysisManager(threading.Thread):
 
             # Enable network routing.
             self.route_network()
+
+            # Run auxiliary modules
+            self.aux = RunAuxiliary(self.task, self.machine, self.guest_manager)
+            self.aux.start()
 
             # By the time start returns it will have fully started the Virtual
             # Machine. We can now safely release the machine lock.

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -14,12 +14,15 @@ from lib.cuckoo.common.exceptions import CuckooOperationalError
 
 log = logging.getLogger(__name__)
 
+
 class Sniffer(Auxiliary):
     def __init__(self):
         Auxiliary.__init__(self)
         self.proc = None
 
     def start(self):
+        # Get updated machine info
+        self.machine = self.db.view_machine_by_label(self.machine.label)
         if not self.machine.interface:
             log.error("Network interface not defined, network capture aborted")
             return

--- a/modules/machinery/kvm.py
+++ b/modules/machinery/kvm.py
@@ -27,5 +27,4 @@ class KVM(LibVirtMachinery):
 
     def start(self, label, task):
         super(KVM, self).start(label, task)
-        if not self.db.view_machine_by_label(label).interface:
-            self.db.set_machine_interface(label, self._get_interface(label))
+        self.db.set_machine_interface(label, self._get_interface(label))

--- a/modules/machinery/kvm.py
+++ b/modules/machinery/kvm.py
@@ -3,10 +3,29 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import xml.etree.ElementTree as ET
+
 from lib.cuckoo.common.abstracts import LibVirtMachinery
+
 
 class KVM(LibVirtMachinery):
     """Virtualization layer for KVM based on python-libvirt."""
 
     # Set KVM connection string.
     dsn = "qemu:///system"
+
+    def _get_interface(self, label):
+        xml = ET.fromstring(self._lookup(label).XMLDesc())
+        elem = xml.find("./devices/interface[@type='network']")
+        if elem is None:
+            return elem
+        elem = elem.find("target")
+        if elem is None:
+            return None
+
+        return elem.attrib["dev"]
+
+    def start(self, label, task):
+        super(KVM, self).start(label, task)
+        if not self.db.view_machine_by_label(label).interface:
+            self.db.set_machine_interface(label, self._get_interface(label))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.8.0
 beautifulsoup4==4.4.1
 cffi==1.6.0
 chardet==2.3.0
-cryptography==1.3.2
+cryptography==1.7.2
 Django==1.8.4
 dpkt==1.8.7
 ecdsa==0.13
@@ -26,11 +26,11 @@ pyasn1==0.1.8
 pycparser==2.14
 pymisp==2.4.54
 pymongo==3.0.3
-pyOpenSSL==0.15.1
+pyOpenSSL==16.2.0
 python-dateutil==2.4.2
 python-editor==0.3
 python-magic==0.4.6
-requests==2.7.0
+requests==2.13.0
 six==1.9.0
 SQLAlchemy==1.0.8
 tlslite-ng==0.6.0-alpha3


### PR DESCRIPTION
- Update `requirements.txt` to work with OpenSSL 1.1.0c
- Automatically detect and use the `vnetx` interface assigned to KVM on the VM start for sniffing and routing, rather than the `virbr` bridge
- Fix `vpn_status()` in `rooter.py` to properly detect running VPNs in Debian and Ubuntu 