### PR TITLE
Signtool Authenticode Verification Integration

### DIFF
--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2014-2017 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+import json
+import logging
+import os
+import subprocess
+
+from lib.common.abstracts import Auxiliary
+from lib.common.results import NetlogFile
+from cStringIO import StringIO
+
+log = logging.getLogger(__name__)
+
+class SignTool(Auxiliary):
+    """
+    This class contains the information about the signature verification for Microsoft Windows PE files.
+    This class requires signtool.exe in the analyzer/windows/bin directory so it will be copied to the guest VM.
+    Signtool.exe is packaged with Windows SDKs and can be downloaded from Microsoft.
+    """
+    def __init__(self, options, analyzer):
+        """
+        Creates a SignTool object.
+
+        :param options:  An options variable as required by Auxiliary.
+        :param analyzer:  An analyzer object required by Auxiliary.
+        """
+        Auxiliary.__init__(self, options, analyzer)
+
+        # Check to see if signtool is available...
+        if os.path.isfile(os.path.join(os.getcwd(), 'bin', 'signtool.exe')):
+            self.enabled = True
+        else:
+            self.enabled = False
+
+    def start(self):
+        try:
+            # Return False if this is not enabled.
+            if not self.enabled:
+                return False
+
+            if self.analyzer.config.category != 'file':
+                log.debug("Can only run signtool.exe on a file.")
+                return False
+
+            signtool_path = os.path.join(os.getcwd(), 'bin', 'signtool.exe')
+
+            if not os.path.isfile(signtool_path):
+                log.info("signtool.exe is not available at {0}, skipping verification.".format(signtool_path))
+                return False
+
+            log.debug("Verifying PE Authenticode.")
+
+            filepath = os.path.join(os.environ["TEMP"], self.analyzer.config.file_name)
+
+            cmds = [signtool_path]
+            cmds.append("verify")
+            cmds.append("/pa")
+            cmds.append("/v")
+
+            cmds.append(filepath)
+
+            signtoolproc = subprocess.Popen(cmds, stdout=subprocess.PIPE)
+            signtoolproc.wait()
+
+            if signtoolproc.returncode == 0:
+                pass
+            else:
+                pass
+
+            nf = NetlogFile()
+            nf.init("aux/signtool.txt")
+            nf.send("".join(signtoolproc.stdout))
+            nf.close()
+
+        except:
+            import traceback
+            log.exception(traceback.format_exc())
+
+        return True

--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -2,16 +2,15 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-import json
 import logging
 import os
 import subprocess
 
 from lib.common.abstracts import Auxiliary
 from lib.common.results import NetlogFile
-from cStringIO import StringIO
 
 log = logging.getLogger(__name__)
+
 
 class SignTool(Auxiliary):
     """

--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -36,7 +36,7 @@ class SignTool(Auxiliary):
 
     def start(self):
         """
-        Starts the signtool.exe analysis and saves the results in aux/signtool.txt.
+        Starts the signtool.exe analysis and saves the results in aux/signtool.json.
 
         :return:  True if this function worked, False if it was unable to run.  This is not the same
             as True or False if the Authenticode verification worked!

--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -34,6 +34,12 @@ class SignTool(Auxiliary):
             self.enabled = False
 
     def start(self):
+        """
+        Starts the signtool.exe analysis and saves the results in aux/signtool.txt.
+
+        :return:  True if this function worked, False if it was unable to run.  This is not the same
+            as True or False if the Authenticode verification worked!
+        """
         try:
             # Return False if this is not enabled.
             if not self.enabled:

--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import subprocess
+import json
 
 from lib.common.abstracts import Auxiliary
 from lib.common.results import NetlogFile
@@ -67,14 +68,18 @@ class SignTool(Auxiliary):
             signtoolproc = subprocess.Popen(cmds, stdout=subprocess.PIPE)
             signtoolproc.wait()
 
+            results = {}
+
             if signtoolproc.returncode == 0:
-                pass
+                results['verified'] = True
             else:
-                pass
+                results['verified'] = False
+
+            results['output'] = "".join(signtoolproc.stdout)
 
             nf = NetlogFile()
-            nf.init("aux/signtool.txt")
-            nf.send("".join(signtoolproc.stdout))
+            nf.init("aux/signtool.json")
+            nf.send(json.dumps(results))
             nf.close()
 
         except:

--- a/analyzer/windows/modules/auxiliary/signtool.py
+++ b/analyzer/windows/modules/auxiliary/signtool.py
@@ -55,8 +55,6 @@ class SignTool(Auxiliary):
                 log.info("signtool.exe is not available at {0}, skipping verification.".format(signtool_path))
                 return False
 
-            log.debug("Verifying PE Authenticode.")
-
             filepath = os.path.join(os.environ["TEMP"], self.analyzer.config.file_name)
 
             cmds = [signtool_path]

--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -365,10 +365,14 @@ class PortableExecutable(object):
         results["pe_timestamp"] = self._get_timestamp()
         results["pdb_path"] = self._get_pdb_path()
         results["signature"] = self._get_signature()
-        results["signature_verification_verified"] = self._get_signature_verification()['verified']
-        results["signature_verification_output"] = \
-            self._get_signature_verification()["output"].replace('\r','')
+
+        sigverification = self._get_signature_verification()
+        if sigverification is not None:
+            results["signature_verification_verified"] = sigverification['verified']
+            results["signature_verification_output"] = sigverification["output"].replace('\r','')
+
         results["imported_dll_count"] = len([x for x in results["pe_imports"] if x.get("dll")])
+
         return results
 
 

--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -365,7 +365,9 @@ class PortableExecutable(object):
         results["pe_timestamp"] = self._get_timestamp()
         results["pdb_path"] = self._get_pdb_path()
         results["signature"] = self._get_signature()
-        results["signature_verification"] = self._get_signature_verification()
+        results["signature_verification_verified"] = self._get_signature_verification()['verified']
+        results["signature_verification_output"] = \
+            self._get_signature_verification()["output"].replace('\r','')
         results["imported_dll_count"] = len([x for x in results["pe_imports"] if x.get("dll")])
         return results
 

--- a/web/templates/analysis/static/_pe32.html
+++ b/web/templates/analysis/static/_pe32.html
@@ -54,6 +54,22 @@
                             <th>Locality</th>
                             <td>{{cert.locality}}</td>
                         </tr>
+                        {% if analysis.static.signature_verification_verified %}
+                        <tr>
+                            <th>Verified</th>
+                            {% if analysis.static.signature_verification_verified %}
+                            <td><span class="label label-success">Yes</span></td>
+                            {% else %}
+                            <td><span class="label label-danger">No</span></td>
+                            {% endif %}
+                        </tr>
+                        {% endif %}
+                        {% if analysis.static.signature_verification_output %}
+                        <tr>
+                            <th>Signtool.exe Output</th>
+                            <td><pre>{{analysis.static.signature_verification_output}}</pre></td>
+                        </tr>
+                        {% endif %}
                     </table>
                     {% endfor %}
                 </div>

--- a/web/templates/analysis/static/_pe32.html
+++ b/web/templates/analysis/static/_pe32.html
@@ -54,7 +54,7 @@
                             <th>Locality</th>
                             <td>{{cert.locality}}</td>
                         </tr>
-                        {% if analysis.static.signature_verification_verified %}
+                        {% if analysis.static.signature_verification_output %}
                         <tr>
                             <th>Verified</th>
                             {% if analysis.static.signature_verification_verified %}
@@ -63,8 +63,6 @@
                             <td><span class="label label-danger">No</span></td>
                             {% endif %}
                         </tr>
-                        {% endif %}
-                        {% if analysis.static.signature_verification_output %}
                         <tr>
                             <th>Signtool.exe Output</th>
                             <td><pre>{{analysis.static.signature_verification_output}}</pre></td>


### PR DESCRIPTION
This requires signtool.exe in analyzer/windows/bin.  This displays if the signature verifies or not in the Django web interface along with detailed information from signtool.  I have not added this info to the static reports as it appears if the static reports don't contain signature information, from what I can tell.