### PR TITLE
Fix UnicodeEncodeError of TaskHandler.

### DIFF
--- a/cuckoo/core/log.py
+++ b/cuckoo/core/log.py
@@ -43,7 +43,7 @@ class TaskHandler(logging.Handler):
             return
 
         with open(cwd("cuckoo.log", analysis=task_id), "a+b") as f:
-            f.write("%s\n" % self.format(record))
+            f.write("%s\n" % self.format(record).encode("utf-8"))
 
 class ConsoleHandler(logging.StreamHandler):
     """Logging to console handler."""


### PR DESCRIPTION
If the process name started by sample is non ASCII, the resultserver will crash.

```
2017-02-21 13:23:04,986 DEBUG: New process (pid=2440, ppid=1796, name=请勿点击.exe)
2017-02-21 13:23:04,988 ERROR: FIXME - exception in resultserver connection
...
UnicodeEncodeError: 'ascii' codec can't encode characters in position 97-100: ordinal not in range(128)
```