### PR TITLE
Fixed AttributeError when traversing through VMs.

### DIFF
--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -234,20 +234,20 @@ class vSphere(Machinery):
 
         for dc, dcpath in traverseDCFolders(conn, conn.content.rootFolder.childEntity):
             for vm in traverseVMFolders(conn, dc.vmFolder.childEntity):
-                try:
+                if hasattr(vm.summary.config, 'name'):
                     self.VMtoDC[vm.summary.config.name] = dcpath
                     yield vm
-                except AttributeError:
-                    pass
+                else:
+                    continue
 
     def _get_virtual_machine_by_label(self, conn, label):
         """Return the named VirtualMachine managed object"""
         for vm in self._get_virtual_machines(conn):
-            try:
+            if hasattr(vm.summary.config, 'name'):
                 if vm.summary.config.name == label:
                     return vm
-            except AttributeError:
-                pass
+            else:
+                continue
 
     def _get_snapshot_by_name(self, vm, name):
         """Return the named VirtualMachineSnapshot managed object for

--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -234,14 +234,20 @@ class vSphere(Machinery):
 
         for dc, dcpath in traverseDCFolders(conn, conn.content.rootFolder.childEntity):
             for vm in traverseVMFolders(conn, dc.vmFolder.childEntity):
-                self.VMtoDC[vm.summary.config.name] = dcpath
-                yield vm
+                try:
+                    self.VMtoDC[vm.summary.config.name] = dcpath
+                    yield vm
+                except AttributeError:
+                    pass
 
     def _get_virtual_machine_by_label(self, conn, label):
         """Return the named VirtualMachine managed object"""
         for vm in self._get_virtual_machines(conn):
-            if vm.summary.config.name == label:
-                return vm
+            try:
+                if vm.summary.config.name == label:
+                    return vm
+            except AttributeError:
+                pass
 
     def _get_snapshot_by_name(self, vm, name):
         """Return the named VirtualMachineSnapshot managed object for


### PR DESCRIPTION
**Methods '_get_virtual_machines', '_get_virtual_machine_by_label':**
Since the '_vm.summary.config_' instances don't always have a '_name_' attribute, it sometimes fails when traversing through an ESX host with a lot of VMs.
Therefore I caught the _AttributeError_ exceptions.

Tested and worked.