### PR TITLE
processing: clean up temporary file after sorting pcap

### DIFF
--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -965,12 +965,12 @@ def batch_sort(input_iterator, output_path, buffer_size=32000, output_class=None
         for chunk in chunks:
             try:
                 chunk.close()
-            except Exception:
-                pass
+            except Exception as e:
+                log.exception("Error closing chunk: %s", e)
             try:
                 os.remove(chunk.name)
-            except Exception:
-                pass
+            except Exception as e:
+                log.exception("Error removing %s: %s", chunk.name, e)
 
 class SortCap(object):
     """SortCap is a wrapper around the packet lib (dpkt) that allows us to sort pcaps

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -965,6 +965,9 @@ def batch_sort(input_iterator, output_path, buffer_size=32000, output_class=None
         for chunk in chunks:
             try:
                 chunk.close()
+            except Exception:
+                pass
+            try:
                 os.remove(chunk.name)
             except Exception:
                 pass

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -997,7 +997,8 @@ class SortCap(object):
 
     def close(self):
         if self.fd:
-            self.fd.close()
+            if type(self.fd) is dpkt.pcap.Writer:
+                self.fd.close()
             self.fd = None
 
     def next(self):


### PR DESCRIPTION
The files weren't being cleaned up before, which was causing a build-up
of temporary files on our system (one file per analysis).