### PR TITLE
Bugfixes to rooter.py and machine.py

### DIFF
--- a/lib/cuckoo/core/rooter.py
+++ b/lib/cuckoo/core/rooter.py
@@ -14,7 +14,6 @@ from lib.cuckoo.common.config import Config
 
 cfg = Config()
 log = logging.getLogger(__name__)
-unixpath = tempfile.mktemp()
 lock = threading.Lock()
 
 vpns = {}
@@ -26,30 +25,32 @@ def rooter(command, *args, **kwargs):
         return
 
     lock.acquire()
-
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-
-    if os.path.exists(unixpath):
-        os.remove(unixpath)
-
-    s.bind(unixpath)
-
     try:
-        s.connect(cfg.cuckoo.rooter)
-    except socket.error as e:
-        log.critical("Unable to passthrough root command as we're unable to "
-                     "connect to the rooter unix socket: %s.", e)
-        return
 
-    s.send(json.dumps({
-        "command": command,
-        "args": args,
-        "kwargs": kwargs,
-    }))
+        unixpath = tempfile.mktemp(dir=getattr(cfg.cuckoo, 'rooter_tmp', None))
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 
-    ret = json.loads(s.recv(0x10000))
+        if os.path.exists(unixpath):
+            os.remove(unixpath)
 
-    lock.release()
+        s.bind(unixpath)
+
+        try:
+            s.connect(cfg.cuckoo.rooter)
+        except socket.error as e:
+            log.critical("Unable to passthrough root command as we're unable to "
+                         "connect to the rooter unix socket: %s.", e)
+            return
+
+        s.send(json.dumps({
+            "command": command,
+            "args": args,
+            "kwargs": kwargs,
+        }))
+
+        ret = json.loads(s.recv(0x10000))
+    finally:
+        lock.release()
 
     if ret["exception"]:
         log.warning("Rooter returned error: %s", ret["exception"])

--- a/utils/machine.py
+++ b/utils/machine.py
@@ -25,7 +25,7 @@ def update_conf(machinery, args, action=None):
         if "=" in line and line.split("=")[0].strip() == "machines":
             # Parse all existing labels.
             labels = line.split("=", 1)[1]
-            labels = [label.strip() for label in labels.split(",")]
+            filter(None, [label.strip() for label in labels.split(",")])
 
             if action == "add":
                 labels.append(args.vmname)

--- a/utils/machine.py
+++ b/utils/machine.py
@@ -25,7 +25,7 @@ def update_conf(machinery, args, action=None):
         if "=" in line and line.split("=")[0].strip() == "machines":
             # Parse all existing labels.
             labels = line.split("=", 1)[1]
-            filter(None, [label.strip() for label in labels.split(",")])
+            labels = filter(None, [label.strip() for label in labels.split(",")])
 
             if action == "add":
                 labels.append(args.vmname)

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -236,7 +236,10 @@ if __name__ == "__main__":
             except Exception as e:
                 log.exception("Error executing command")
 
-            server.sendto(json.dumps({
-                "output": output,
-                "exception": str(e) if e else None,
-            }), addr)
+            try:
+                server.sendto(json.dumps({
+                    "output": output,
+                    "exception": str(e) if e else None,
+                }), addr)
+            except Exception as ex:
+                log.exception("Error while sending response to: %r", addr)

--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -236,10 +236,7 @@ if __name__ == "__main__":
             except Exception as e:
                 log.exception("Error executing command")
 
-            try:
-                server.sendto(json.dumps({
-                    "output": output,
-                    "exception": str(e) if e else None,
-                }), addr)
-            except Exception as ex:
-                log.exception("Error while sending response to: %r", addr)
+            server.sendto(json.dumps({
+                "output": output,
+                "exception": str(e) if e else None,
+            }), addr)


### PR DESCRIPTION
This pull request introduces three changes:

 * `rooter.py` - Fixed a bug where lock would not be released on error
 * `rooter.py` - Catch exception if response cannot be sent to client UNIX sock
 * `machine.py` - Allow empty `machines=` in virtualbox.conf before adding first VM

I have brought my https://github.com/HarryR/cockatoo branch up to date with Cuckoo master, these patches are required for basic operation of Cuckoo (Distributed still doesn't work, as will have to submit separate patches for that).

This should be quick & easy to review & merge.

If you have any questions, just ask :)

Cheers - Harry