### PR TITLE
Add phrases to human.py

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/auxiliary/human.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/human.py
@@ -51,6 +51,7 @@ def foreach_child(hwnd, lparam):
         "finish",
         "end",
         "allow access",
+        "always allow",
         "remind me later",
         "save", "sauvegarder"
     ]
@@ -58,7 +59,8 @@ def foreach_child(hwnd, lparam):
     # List of buttons labels to not click.
     dontclick = [
         "don't run",
-        "i do not accept"
+        "i do not accept",
+        "never allow"
     ]
 
     classname = create_unicode_buffer(50)


### PR DESCRIPTION
click on "always allow", don't click on "never allow"

In Acrobat Reader, I encountered the following issue:

    [modules.auxiliary.human] INFO: Found button "&Open this file", clicking it
    [modules.auxiliary.human] INFO: Found button "&Open this file", clicking it
    [modules.auxiliary.human] INFO: Found button "&Always allow opening files of this type", clicking it
    [modules.auxiliary.human] INFO: Found button "&Always allow opening files of this type", clicking it
    [modules.auxiliary.human] INFO: Found button "&Never allow opening files of this type", clicking it
    [modules.auxiliary.human] INFO: Found button "&Never allow opening files of this type", clicking it
    [modules.auxiliary.human] INFO: Found button "OK", clicking it

This ended up not opening the file, because it only considered the "open" part. I suspect that a rule to click on "always allow" and not click on "never allow" is universal enough to be useful for everyone.