### PR TITLE
Some basic template edits to add route information 

### DIFF
--- a/cuckoo/web/static/js/cuckoo/submission.js
+++ b/cuckoo/web/static/js/cuckoo/submission.js
@@ -2320,6 +2320,7 @@ var SubmissionTaskTable = function () {
 				item.date_added = moment(item.added_on).format('DD/MM/YYYY');
 				item.time_added = moment(item.added_on).format('HH:mm');
 				item.is_ready = item.status == 'reported';
+				item.name = item.guest.name;
 				return item;
 			});
 

--- a/cuckoo/web/static/js/handlebars-templates.js
+++ b/cuckoo/web/static/js/handlebars-templates.js
@@ -447,8 +447,12 @@ this["HANDLEBARS_TEMPLATES"]["submission-task-table-body"] = Handlebars.template
     + alias3(((helper = (helper = helpers.time_added || (depth0 != null ? depth0.time_added : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"time_added","hash":{},"data":data}) : helper)))
     + "\n		</td>\n		<td>"
     + alias3(((helper = (helper = helpers.target || (depth0 != null ? depth0.target : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"target","hash":{},"data":data}) : helper)))
+    + "</td>\n      <td>"
+    + alias3(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
     + "</td>\n		<td>"
     + alias3(((helper = (helper = helpers['package'] || (depth0 != null ? depth0['package'] : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"package","hash":{},"data":data}) : helper)))
+    + "</td>\n          <td>"
+    + alias3(((helper = (helper = helpers['route'] || (depth0 != null ? depth0['route'] : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"route","hash":{},"data":data}) : helper)))
     + "</td>\n		<td><span class=\"status status-"
     + alias3(((helper = (helper = helpers.status || (depth0 != null ? depth0.status : depth0)) != null ? helper : alias1),(typeof helper === alias2 ? helper.call(depth0,{"name":"status","hash":{},"data":data}) : helper)))
     + "\"></span> "

--- a/cuckoo/web/templates/analysis/pages/summary/_info.html
+++ b/cuckoo/web/templates/analysis/pages/summary/_info.html
@@ -48,6 +48,7 @@
                                 <th>Label</th>
                                 <th>Started On</th>
                                 <th>Shutdown On</th>
+                                <th>Route</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -56,6 +57,7 @@
                                 <td>{{report.analysis.info.machine.label}}</td>
                                 <td>{{report.analysis.info.machine.started_on}}</td>
                                 <td>{{report.analysis.info.machine.shutdown_on}}</td>
+                                <td>{{report.analysis.info.route}}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/cuckoo/web/templates/submission/postsubmit.html
+++ b/cuckoo/web/templates/submission/postsubmit.html
@@ -32,7 +32,9 @@
                             <th>Task ID</th>
                             <th>Date</th>
                             <th>Filename / URL</th>
+                            <th>Machine</th>
                             <th>Package</th>
+                            <th>Route</th>
                             <th>Status</th>
                         </tr>
                     </thead>


### PR DESCRIPTION
These changes edit the summary and post page to add more details about the route option selected for historical review. I also added the machine name to the post page, typically needed if you plan to interact with the specific machine. 