### PR TITLE
improve linux strace/stap log parsing

### DIFF
--- a/cuckoo/processing/platform/linux.py
+++ b/cuckoo/processing/platform/linux.py
@@ -117,7 +117,7 @@ class StapParser(object):
                 parts = re.match("^(.+)?@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) =()()$", rest)
 
             if not parts:
-                print "Could not parse syscall trace line: %s", line.strip()
+                log.warning("Could not parse syscall trace line: %s", line)
                 continue
 
             pname, ip, pid, fn, arguments, retval, ecode = parts.groups()

--- a/cuckoo/processing/platform/linux.py
+++ b/cuckoo/processing/platform/linux.py
@@ -32,7 +32,7 @@ class FilteredProcessLog(list):
         return True
 
 class LinuxSystemTap(BehaviorHandler):
-    """Parses systemtap generated plaintext logs (see data/strace.stp)."""
+    """Parses systemtap generated plaintext logs (see stuff/strace.stp)."""
 
     key = "processes"
 

--- a/cuckoo/processing/platform/linux.py
+++ b/cuckoo/processing/platform/linux.py
@@ -112,9 +112,12 @@ class StapParser(object):
             dtms = datetime.timedelta(0, 0, int(datetimepart.split(".", 1)[1]))
             dt = dateutil.parser.parse(datetimepart.split(".", 1)[0]) + dtms
 
-            parts = re.match("^(.+)@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) = (\S+){0,1}\s{0,1}(\(\w+\)){0,1}$", rest)
+            parts = re.match("^(.+)?@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) = (\S+){0,1}\s{0,1}(\(\w+\)){0,1}$", rest)
             if not parts:
-                log.warning("Could not parse syscall trace line: %s", line)
+                parts = re.match("^(.+)?@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) =()()$", rest)
+
+            if not parts:
+                print "Could not parse syscall trace line: %s", line.strip()
                 continue
 
             pname, ip, pid, fn, arguments, retval, ecode = parts.groups()


### PR DESCRIPTION
fix linux log parser

poc of lines

```
import re
lines = [
    'Fri Apr 21 04:50:39 2017.564717 @8050a46[1155] read(6, 0xbf998f5b, 1) = 1',
    'Fri Apr 21 04:50:39 2017.564790 @8050a46[1155] read(6, 0xbf998f5c, 1) = 1',
    'Fri Apr 21 04:50:39 2017.564863 @8050a46[1155] read(6, 0xbf998f5d, 1) = 1',
    'Fri Apr 21 04:50:39 2017.564937 @8050a46[1155] read(6, 0xbf998f5e, 1) = 1',
    'Fri Apr 21 04:50:39 2017.565011 @8050a46[1155] read(6, 0xbf998f5f, 1) = 1',
    'Fri Apr 21 04:50:39 2017.565190 @8050716[1155] close(6) = 0',
    'Fri Apr 21 04:50:39 2017.565718 @8050906[1155] ioctl(4, 35111, 0xbf998ec0) = 0',
    'Fri Apr 21 04:50:39 2017.566210 @8050716[1155] close(4) = 0',
    'Fri Apr 21 04:50:39 2017.566971 @8050773[1155] fork() = 1156',
    'Fri Apr 21 04:50:39 2017.568741 @8050773[1156] fork() = 1157',
    'Fri Apr 21 04:50:39 2017.569886 @8050b8a[1156] write(1, "BUILD SYNOPSISCLIENT", 21) = 21',
    'Fri Apr 21 04:50:39 2017.570579 @80506bf[1156] exit(0) =',
    'Fri Apr 21 04:50:39 2017.568378 @80553d3[1155] wait4(1156, 0xbf99b580, 0x0, 0x0) = 1156',
    'Fri Apr 21 04:50:39 2017.572176 @8050b8a[1155] write(1, "BUILD SYNOPSISCLIENT", 21) = 21',
    'Fri Apr 21 04:50:39 2017.572357 @80506bf[1155] exit(0) ='
]

for line in lines:
    # 'Thu May  7 14:58:43 2015.390178 python@7f798cb95240[2114] close(6) = 0'
    # datetime is 31 characters
    datetimepart, rest = line[:31], line[32:]
    parts = re.match("^(.+)?@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) = (\S+){0,1}\s{0,1}(\(\w+\)){0,1}$", rest)
    if not parts:
        parts = re.match("^(.+)?@([a-f0-9]+)\[(\d+)\] (\w+)\((.*)\) =()()$", rest)

    if not parts:
        print "Could not parse syscall trace line: %s", line.strip()
        continue
```