### PR TITLE
Update _irma.html

### DIFF
--- a/cuckoo/web/templates/analysis/pages/static/_irma.html
+++ b/cuckoo/web/templates/analysis/pages/static/_irma.html
@@ -1,5 +1,5 @@
 <section id="static_irma">
-    {% if report.analysis.irma and report.analysis.irma.status %}
+    {% if report.analysis.irma %}
     <table class="table table-striped table-bordered">
         <tr>
             <th>IRMA</th>


### PR DESCRIPTION
When irma checks file with antiviruses and marks file as malisious we see table with results. 
If file is clean we see result "No IRMA results available.". But if irma was terminated we see "No IRMA results available." too.
I delete string "and report.analysis.irma.status" to display table with antiviruses if probe results is clean.