### PR TITLE
Update irma.py

### DIFF
--- a/cuckoo/processing/irma.py
+++ b/cuckoo/processing/irma.py
@@ -67,7 +67,7 @@ class Irma(Processing):
 
         result = None
 
-        while result is None or result.get("status") != self.IRMA_FINISHED_STATUS:
+        while result is None or result.get("status") != self.IRMA_FINISHED_STATUS or time.time() < self.time_start + self.timeout:
             log.debug("Polling for results for ID %s", init.get("id"))
             url = urlparse.urljoin(
                 self.url, "/api/v1.1/scans/%s" % init.get("id")
@@ -108,6 +108,8 @@ class Irma(Processing):
         self.scan = int(self.options.get("scan", 0))
         self.force = int(self.options.get("force", 0))
 
+        self.time_start = time.time()
+        
         sha256 = Files.sha256_file(self.file_path)
 
         results = self._get_results(sha256)


### PR DESCRIPTION
Added timeout checks for a while loop.
Without this check when irma server breaks, the analyse goes into an infinite loop.