### PR TITLE
Fixed misleading typo

### DIFF
--- a/docs/book/installation/host/routing.rst
+++ b/docs/book/installation/host/routing.rst
@@ -63,7 +63,7 @@ want to run both commands::
     $ sudo sysctl -w net.ipv4.ip_forward=1
 
 Iptables rules are not persistent between reboots, so if want to keep
-them you should use a script or just install ``iptables-persistant``.
+them you should use a script or just install ``iptables-persistent``.
 
 Per-Analysis Network Routing Options
 ====================================


### PR DESCRIPTION
Changed "peristant" to "persistent" in "iptables-persistent" so that copy-pasters will not cry.