### PR TITLE
Add mongodb authentication if username and password is set.

### DIFF
--- a/cuckoo/apps/apps.py
+++ b/cuckoo/apps/apps.py
@@ -352,8 +352,13 @@ def cuckoo_clean():
         host = config("reporting:mongodb:host")
         port = config("reporting:mongodb:port")
         mdb = config("reporting:mongodb:db")
+        username = config("reporting:mongodb:username")
+        password = config("reporting:mongodb:password")
         try:
             conn = pymongo.MongoClient(host, port)
+            if username and password:
+                data_base = conn.get_database(mdb)
+                data_base.authenticate(username, password)
             conn.drop_database(mdb)
             conn.close()
         except:


### PR DESCRIPTION
Add mongodb authentication if username and password is set when executing `cuckoo clean`.