### PR TITLE
opera already uses webkit

### DIFF
--- a/cuckoo/web/src/scripts/app.js
+++ b/cuckoo/web/src/scripts/app.js
@@ -124,7 +124,7 @@ class CuckooWeb {
     // recommended browser list.
     static isRecommendedBrowser() {
 
-        var recommended = ['firefox', 'chrome', 'webkit', 'chromium'];
+        var recommended = ['firefox', 'chrome', 'webkit', 'chromium', 'opera'];
         var isRecommended = false;
 
         for(var recommendation in recommended) {


### PR DESCRIPTION
https://www.siliconrepublic.com/life/opera-hits-300m-users-switches-to-webkit-and-chromium

WebKit is a layout engine software component for rendering web pages in web browsers. It powers Apple's Safari web browser. It was forked by Google to create Blink, used by Chromium-based browsers such as Google Chrome and Opera.
source: https://en.wikipedia.org/wiki/WebKit