### PR TITLE
Add task/summary resource to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ local/
 
 # Cuckoo package stuff
 cuckoo/data-private/.cwd
+cuckoo/data-private/cwd/hashes.txt
+cuckoo/data/monitor/
+MANIFEST.in
 
 # Frontend compilation services
 node_modules/

--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -388,7 +388,7 @@ def tasks_report(task_id, report_format="json"):
 
 @app.route("/tasks/summary/<int:task_id>")
 @app.route("/v1/tasks/summary/<int:task_id>")
-def tasks_report(task_id):
+def tasks_summary(task_id):
     report_path = cwd(
         "storage", "analyses", "%d" % task_id, "reports",
         "report.json"

--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -408,7 +408,8 @@ def tasks_summary(task_id):
     except KeyError:
         pass
 
-    return jsonify(report)
+    response = dict(task=report)
+    return jsonify(response)
 
 @app.route("/tasks/screenshots/<int:task_id>")
 @app.route("/v1/tasks/screenshots/<int:task_id>")

--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -482,7 +482,9 @@ def files_view(md5=None, sha256=None, sample_id=None):
     if not sample:
         return json_error(404, "File not found")
 
+    tasks = sorted(list(map(lambda t: t.id, db.list_tasks(sample_id=sample.id))))
     response["sample"] = sample.to_dict()
+    response["sample"]["tasks"] = tasks
     return jsonify(response)
 
 @app.route("/files/get/<sha256>")

--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -408,8 +408,7 @@ def tasks_summary(task_id):
     except KeyError:
         pass
 
-    response = dict(task=report)
-    return jsonify(response)
+    return jsonify(report)
 
 @app.route("/tasks/screenshots/<int:task_id>")
 @app.route("/v1/tasks/screenshots/<int:task_id>")

--- a/docs/book/usage/api.rst
+++ b/docs/book/usage/api.rst
@@ -148,6 +148,8 @@ each one. For details click on the resource name.
 | ``GET`` :ref:`tasks_report`         | Returns the report generated out of the analysis of the task associated with the specified ID.                   |
 |                                     | You can optionally specify which report format to return, if none is specified the JSON report will be returned. |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
+| ``GET`` :ref:`tasks_summary`        | Returns a condensed report in JSON format.                                                                       |
++-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_shots`          | Retrieves one or all screenshots associated with a given analysis task ID.                                       |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_rereport`       | Re-run reporting for task associated with a given analysis task ID.                                              |
@@ -606,6 +608,31 @@ Returns the report associated with the specified task ID.
 
 * ``200`` - no error
 * ``400`` - invalid report format
+* ``404`` - report not found
+
+.. _tasks_summary:
+
+/tasks/summary
+--------------
+
+**GET /tasks/summary/** *(int: id)* **/** *(str: format)*
+
+Returns a condensed report associated with the specified task ID in JSON format.
+
+**Example request**.
+
+.. code-block:: bash
+
+    curl http://localhost:8090/tasks/summary/1
+
+**Parameters**:
+
+* ``id`` *(required)* *(int)* - ID of the task to get the report for
+* ``format`` *(optional)* - format of the report to retrieve [json/html/all/dropped/package_files]. If none is specified the JSON report will be returned. ``all`` returns all the result files as tar.bz2, ``dropped`` the dropped files as tar.bz2, ``package_files`` files uploaded to host by analysis packages.
+
+**Status codes**:
+
+* ``200`` - no error
 * ``404`` - report not found
 
 .. _tasks_shots:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,45 +191,10 @@ class TestAPI(object):
         r = self.app.get("/tasks/reschedule/666")
         assert r.status_code == 404
 
-    def test_tasks_view(self):
+    def test_files_view(self):
         task_id = self.create_task()
 
         t = json.loads(self.app.get("/tasks/view/%s" % task_id).data)
-
-        # Fetch by sample id.
-        r = self.app.get(
-            "/files/view/id/%s" % t["task"]["sample_id"]
-        )
-        assert r.status_code == 200
-        sample = json.loads(r.data)
-        assert sample["sample"]["id"] == t["task"]["sample_id"]
-
-        # Fetch by md5.
-        r = self.app.get("/files/view/md5/f2d886558b2866065c3da842bfe13ce6")
-        sample = json.loads(r.data)
-        assert sample["sample"]["id"] == 1
-
-        # Fetch by sha256.
-        r = self.app.get("/files/view/sha256/c6039bfcdfdfbf714caa94a3bb837a6a4907f3f84ed580ce2916bae7676b68f9")
-        sample = json.loads(r.data)
-        assert sample["sample"]["id"] == 1
-
-        # Fetch not found id.
-        r = self.app.get("/files/view/id/69")
-        assert r.status_code == 404
-
-        # Fetch not found md5.
-        r = self.app.get("/files/view/md5/zzz886558b2866065c3da842bfe13ce6")
-        assert r.status_code == 404
-
-        # Fetch not found sha256.
-        r = self.app.get("/files/view/sha256/zzz39bfcdfdfbf714caa94a3bb837a6a4907f3f84ed580ce2916bae7676b68f9")
-        assert r.status_code == 404
-
-    def test_tasks_summary(self):
-        task_id = self.create_task()
-
-        t = json.loads(self.app.get("/tasks/summary/%s" % task_id).data)
 
         # Fetch by sample id.
         r = self.app.get(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,10 +191,45 @@ class TestAPI(object):
         r = self.app.get("/tasks/reschedule/666")
         assert r.status_code == 404
 
-    def test_files_view(self):
+    def test_tasks_view(self):
         task_id = self.create_task()
 
         t = json.loads(self.app.get("/tasks/view/%s" % task_id).data)
+
+        # Fetch by sample id.
+        r = self.app.get(
+            "/files/view/id/%s" % t["task"]["sample_id"]
+        )
+        assert r.status_code == 200
+        sample = json.loads(r.data)
+        assert sample["sample"]["id"] == t["task"]["sample_id"]
+
+        # Fetch by md5.
+        r = self.app.get("/files/view/md5/f2d886558b2866065c3da842bfe13ce6")
+        sample = json.loads(r.data)
+        assert sample["sample"]["id"] == 1
+
+        # Fetch by sha256.
+        r = self.app.get("/files/view/sha256/c6039bfcdfdfbf714caa94a3bb837a6a4907f3f84ed580ce2916bae7676b68f9")
+        sample = json.loads(r.data)
+        assert sample["sample"]["id"] == 1
+
+        # Fetch not found id.
+        r = self.app.get("/files/view/id/69")
+        assert r.status_code == 404
+
+        # Fetch not found md5.
+        r = self.app.get("/files/view/md5/zzz886558b2866065c3da842bfe13ce6")
+        assert r.status_code == 404
+
+        # Fetch not found sha256.
+        r = self.app.get("/files/view/sha256/zzz39bfcdfdfbf714caa94a3bb837a6a4907f3f84ed580ce2916bae7676b68f9")
+        assert r.status_code == 404
+
+    def test_tasks_summary(self):
+        task_id = self.create_task()
+
+        t = json.loads(self.app.get("/tasks/summary/%s" % task_id).data)
 
         # Fetch by sample id.
         r = self.app.get(


### PR DESCRIPTION
Returns a condenced JSON report. It is the standard JSON report, with
the following verbose structures removed to reduce the response size:

- ["procmemory"]
- ["behavior"]["generic"]
- ["behavior"]["apistats"]
- ["behavior"]["processes"]
- ["debug"]
- ["screenshots"]
- ["metadata"]

The average summary report is only 132.6 KB compared to nearly 9 MB for the full report (my VMs are widescreen, so the screenshots are large).

Also, I added a few paths to `.gitignore` that are modified when `setup.py develop` is run, to prevent myself and others from committing files that we shouldn't. Let me know if I should remove those lines.  