### PR TITLE
reorder host installation doc pages

### DIFF
--- a/docs/book/installation/host/index.rst
+++ b/docs/book/installation/host/index.rst
@@ -10,7 +10,7 @@ documentation.
 
     requirements
     installation
-    routing
     cwd
     configuration
+    routing
     configuration_android


### PR DESCRIPTION
It makes sense to put the "Configuration" and "Cuckoo Working Directory" pages before the "Per-Analysis Network Routing" page.

The current order seems a little bit confusing on a read through, since the routing page mentions a few configuration directives before even mentioning the config files.