### PR TITLE
Error handling for sign.meta.description

### DIFF
--- a/cuckoo/web/templates/analysis/pages/summary/_file.html
+++ b/cuckoo/web/templates/analysis/pages/summary/_file.html
@@ -77,7 +77,11 @@
                     {% if report.analysis.target.file.yara %}
                         <ul style="margin-bottom: 0;">
                             {% for sign in report.analysis.target.file.yara %}
-                                <li>{{ sign.name }} - {{ sign.meta.description }}</li>
+                                <li>{{ sign.name }} 
+                                    {% if sign.meta.description %}-
+                                        {{ sign.meta.description }}
+                                </li>
+                                    {% endif %}
                             {% endfor %}
                         </ul>
                     {% else %}


### PR DESCRIPTION
Not all my yara rules have a description (apparently). This crashes the summary page if that is the case. That's the way I fixed it on my side for now. You may have a better way, but thought I'd let you know in the meanwhile.

(There are other files too that might need editing)