### PR TITLE
Add support for URL analysis in cuckoo distributed 

### DIFF
--- a/cuckoo/data-private/distributed/migration/versions/8c3c70a2479b_add_url_column_in_task_table.py
+++ b/cuckoo/data-private/distributed/migration/versions/8c3c70a2479b_add_url_column_in_task_table.py
@@ -1,0 +1,22 @@
+"""add url column in task table
+
+Revision ID: 8c3c70a2479b
+Revises: 4b86bc0d40aa
+Create Date: 2017-07-04 15:44:27.698132
+
+"""
+
+revision = '8c3c70a2479b'
+down_revision = '4b86bc0d40aa'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column("task", sa.Column("url", sa.Text(), nullable=True))
+
+def downgrade():
+    op.drop_column("task", "url")

--- a/cuckoo/distributed/api.py
+++ b/cuckoo/distributed/api.py
@@ -35,11 +35,22 @@ def submit_task(url, task):
         memory=task["memory"],
         clock=task["clock"],
         enforce_timeout=task["enforce_timeout"],
+        url=task["url"],
     )
+
+    if task["url"]:
+        try:
+            r = requests.post(
+                urlparse.urljoin(url, "/tasks/create/url"),
+                data=data
+            )
+            return r.json()["task_id"]
+        except Exception:
+            pass
 
     # If the file does not exist anymore, ignore it and move on
     # to the next file.
-    if not os.path.isfile(task["path"]):
+    elif not os.path.isfile(task["path"]):
         return task["id"], None
 
     files = {"file": (task["filename"], open(task["path"], "rb"))}

--- a/cuckoo/distributed/db.py
+++ b/cuckoo/distributed/db.py
@@ -81,6 +81,7 @@ class Task(db.Model, Serializer):
     id = db.Column(db.Integer, primary_key=True)
     path = db.Column(db.Text)
     filename = db.Column(db.Text)
+    url = db.Column(db.Text)
     package = db.Column(db.Text)
     timeout = db.Column(db.Integer)
     priority = db.Column(db.Integer)
@@ -111,13 +112,14 @@ class Task(db.Model, Serializer):
 
     __table_args__ = db.Index("ix_node_task", node_id, task_id),
 
-    def __init__(self, path=None, filename=None, package=None, timeout=None,
+    def __init__(self, path=None, filename=None, url=None, package=None, timeout=None,
                  priority=None, options=None, machine=None, platform=None,
                  tags=None, custom=None, owner=None, memory=None, clock=None,
                  enforce_timeout=None, node_id=None, task_id=None,
                  status=PENDING):
         self.path = path
         self.filename = filename
+        self.url = url
         self.package = package
         self.timeout = timeout
         self.priority = priority

--- a/cuckoo/distributed/views/api.py
+++ b/cuckoo/distributed/views/api.py
@@ -183,8 +183,8 @@ def task_list():
 
 @blueprint.route("/task", methods=["POST"])
 def task_post():
-    if "file" not in request.files:
-        return json_error(404, "No file has been provided")
+    if "file" not in request.files and "url" not in request.form:
+        return json_error(404, "No file or URL has been provided")
 
     args = dict(
         package=request.form.get("package"),
@@ -199,16 +199,22 @@ def task_post():
         memory=request.form.get("memory"),
         clock=request.form.get("clock"),
         enforce_timeout=request.form.get("enforce_timeout"),
+        url=request.form.get("url"),
     )
 
-    f = request.files["file"]
+    if "file" in request.files:
+        f = request.files["file"]
+        fd, path = tempfile.mkstemp(dir=settings.samples_directory)
+        f.save(path)
+        os.close(fd)
 
-    fd, path = tempfile.mkstemp(dir=settings.samples_directory)
-    f.save(path)
-    os.close(fd)
+        task = Task(path=path, filename=os.path.basename(f.filename), **args)
+        db.session.add(task)
 
-    task = Task(path=path, filename=os.path.basename(f.filename), **args)
-    db.session.add(task)
+    else:
+        task = Task(**args)
+        db.session.add(task)
+
     db.session.commit()
     return jsonify(success=True, task_id=task.id)
 


### PR DESCRIPTION
Usage example: 
`curl http://localhost:9003/api/task -F url="http://www.perdu.com"`

Two commits: one for the small modifications needed in distributed and the other for the migration script since a new field is needed in the task database.