### PR TITLE
Fix for cuckoo distributed migrate

### DIFF
--- a/cuckoo/data-private/distributed/migration/alembic.ini
+++ b/cuckoo/data-private/distributed/migration/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migration
+script_location = .
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Running "cuckoo distributed migrate" currently seem to provoke to following error:

>   FAILED: Path doesn't exist: 'migration'.  Please use the 'init' command to create a new scripts folder.
>  Error migrating your database..

This fixes the alembic configuration.