### PR TITLE
fix path traversal vulnerability

### DIFF
--- a/cuckoo/web/controllers/analysis/export/export.py
+++ b/cuckoo/web/controllers/analysis/export/export.py
@@ -24,12 +24,12 @@ class ExportController:
         size_total = 0
 
         for directory in taken_dirs:
-            destination = "%s/%s" % (path, directory)
+            destination = "%s/%s" % (path, os.path.basename(directory))
             if os.path.isdir(destination):
                 size_total += get_directory_size(destination)
 
         for filename in taken_files:
-            destination = "%s/%s" % (path, filename)
+            destination = "%s/%s" % (path, os.path.basename(filename))
             if os.path.isfile(destination):
                 size_total += os.path.getsize(destination)
 


### PR DESCRIPTION
A path traversal vulnerability in the web export functionality allows users to determine the existence and size of files on the cuckoo host:

Request:
```
POST /analysis/api/task/export_estimate_size/ HTTP/1.1
Host: [...snip...]
User-Agent: [...snip...]
Accept-Language: en-US,en;q=0.5
Referer: [...snip...]
Content-Type: application/json
X-Requested-With: XMLHttpRequest
Content-Length: 73
Cookie: csrftoken=[...snip...]
Connection: close

{"task_id":1,"dirs":[],"files":["../../../../../../../../../etc/passwd"]}
```

Response:
```
HTTP/1.0 200 OK
Date: Tue, 11 Jul 2017 13:57:34 GMT
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Expires: 0
Server: Machete Server
Pragma: no-cache
Cache-Control: no-cache
X-Frame-Options: DENY
Content-Type: application/json
X-Cuckoo-Version: 2.0.3

{"size_human": "386\u00a0bytes", "size": 386}
```