### PR TITLE
Fix for Excel ad PowerPoint 2016 to run automatically.

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/packages/ppt.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/ppt.py
@@ -17,6 +17,7 @@ class PPT(Package):
         ("ProgramFiles", "Microsoft Office", "Office15", "POWERPNT.EXE"),
         ("ProgramFiles", "Microsoft Office", "Office16", "POWERPNT.EXE"),
         ("ProgramFiles", "Microsoft Office 15", "root", "office15", "POWERPNT.EXE"),
+        ("ProgramFiles", "Microsoft Office", "root", "Office16", "POWERPNT.EXE"),
     ]
 
     REGKEYS = [

--- a/cuckoo/data/analyzer/windows/modules/packages/xls.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/xls.py
@@ -18,6 +18,7 @@ class XLS(Package):
         ("ProgramFiles", "Microsoft Office", "Office15", "EXCEL.EXE"),
         ("ProgramFiles", "Microsoft Office", "Office16", "EXCEL.EXE"),
         ("ProgramFiles", "Microsoft Office 15", "root", "office15", "EXCEL.EXE"),
+        ("ProgramFiles", "Microsoft Office", "root", "Office16", "EXCEL.EXE"),
     ]
 
     REGKEYS = [


### PR DESCRIPTION
Hi, 

Excel and PowerPoint from Office 2016 did not start automatically.
I’ve updated Office 2016 path for Excel and Powerpoint.

In the same way as Word 2016 has this path: ("ProgramFiles", "Microsoft Office", "root", "Office16", "WINWORD.EXE"),
There is no equivalent path for Excel and PowerPoint.

Without these paths, both applications did not start automatically.
This fix solves the issue.

Regards, 
Rubén