### PR TITLE
Add in parent process name in the process listing for searchability

### DIFF
--- a/cuckoo/processing/behavior.py
+++ b/cuckoo/processing/behavior.py
@@ -156,6 +156,11 @@ class GenericBehavior(BehaviorHandler):
             for key, value in process["summary"].items():
                 process["summary"][key] = list(value)
 
+            # having parent process name in the report is incredibly useful in ElasticSearch
+            for item in self.processes.values():
+                if item["process_id"] == process["parent_id"]:
+                    process["parent_name"] = item["process_name"]
+
         return self.processes.values()
 
 class ApiStats(BehaviorHandler):


### PR DESCRIPTION
I'm not great at python, feel free to refactor this.

In short: I use Elastic, and dig through cuckoo reports there, and without this data it's difficult to tie-together a process hierarchy in a query there.