### PR TITLE
Add current index into a cuckoo alias for searchability

### DIFF
--- a/cuckoo/reporting/elasticsearch.py
+++ b/cuckoo/reporting/elasticsearch.py
@@ -185,6 +185,9 @@ class ElasticSearch(Report):
         }[elastic.index_time_pattern])
         self.dated_index = "%s-%s" % (elastic.index, date_index)
 
+        # add this index to the cuckoo alias for searching
+        elastic.client.indices.put_alias(index=dated_index, name='cuckoo')
+
         # Index target information, the behavioral summary, and
         # VirusTotal results.
         doc = {


### PR DESCRIPTION
Add the datestamped cuckoo indexes to a 'cuckoo' alias, so stuff like

`GET http://elastic.cuckoo/cuckoo/_search?q=some.json.path:value`

hits all the indexes, and you don't have to specify them.