### PR TITLE
inetsim with dummy port support

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -786,6 +786,9 @@ class Config(object):
             "inetsim": {
                 "enabled": Boolean(False),
                 "server": String("192.168.56.1"),
+                "dummy_enabled": Boolean(False),
+                "dummy_port": Int(1),
+                "ports": String("7 9 13 17 19 21 22 25 37 69 79 80 110 113 123 443 465 514 990 995 6667")
             },
             "tor": {
                 "enabled": Boolean(False),

--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -302,12 +302,34 @@ class AnalysisManager(threading.Thread):
 
         if self.route == "inetsim":
             machinery = config("cuckoo:cuckoo:machinery")
-            rooter(
-                "inetsim_enable", self.machine.ip,
-                config("routing:inetsim:server"),
-                config("%s:%s:interface" % (machinery, machinery)),
-                str(config("cuckoo:resultserver:port"))
-            )
+
+            if config("routing:inetsim:dummy_enabled"):
+                dest = "{}:{}".format(
+                    config("routing:inetsim:server"),
+                    config("routing:inetsim:dummy_port")
+                )
+                if all(port.isdigit() for port in config("routing:inetsim:ports").split(" ")):
+                    ports = config("routing:inetsim:ports")
+                else:
+                    logging.debug("Non digits found in routing:inetsim:ports value")
+                    ports = False
+            else:
+                dest = config("routing:inetsim:server")
+                ports = False
+
+            if ports:
+                rooter(
+                    "inetsim_enable", self.machine.ip, dest,
+                    config("%s:%s:interface" % (machinery, machinery)),
+                    str(config("cuckoo:resultserver:port")),
+                    ports,
+                )
+            else:
+                rooter(
+                    "inetsim_enable", self.machine.ip, dest,
+                    config("%s:%s:interface" % (machinery, machinery)),
+                    str(config("cuckoo:resultserver:port"))
+                )
 
         if self.route == "tor":
             rooter(
@@ -353,12 +375,34 @@ class AnalysisManager(threading.Thread):
 
         if self.route == "inetsim":
             machinery = config("cuckoo:cuckoo:machinery")
-            rooter(
-                "inetsim_disable", self.machine.ip,
-                config("routing:inetsim:server"),
-                config("%s:%s:interface" % (machinery, machinery)),
-                str(config("cuckoo:resultserver:port"))
-            )
+
+            if config("routing:inetsim:dummy_enabled"):
+                dest = "{}:{}".format(
+                    config("routing:inetsim:server"),
+                    config("routing:inetsim:dummy_port")
+                )
+                if all(port.isdigit() for port in config("routing:inetsim:ports").split(" ")):
+                    ports = config("routing:inetsim:ports")
+                else:
+                    logging.debug("Non digits found in routing:inetsim:ports value")
+                    ports = False
+            else:
+                dest = config("routing:inetsim:server")
+                ports = False
+
+            if ports:
+                rooter(
+                    "inetsim_disable", self.machine.ip, dest,
+                    config("%s:%s:interface" % (machinery, machinery)),
+                    str(config("cuckoo:resultserver:port")),
+                    ports,
+                )
+            else:
+                rooter(
+                    "inetsim_disable", self.machine.ip, dest,
+                    config("%s:%s:interface" % (machinery, machinery)),
+                    str(config("cuckoo:resultserver:port"))
+                )
 
         if self.route == "tor":
             rooter(

--- a/cuckoo/data-private/cwd/conf/routing.conf
+++ b/cuckoo/data-private/cwd/conf/routing.conf
@@ -48,6 +48,9 @@ drop = {{ routing.routing.drop }}
 # type of web service / etc).
 enabled = {{ routing.inetsim.enabled }}
 server = {{ routing.inetsim.server }}
+dummy_enabled = {{ routing.inetsim.dummy_enabled }}
+dummy_port = {{ routing.inetsim.dummy_port }}
+ports = {{ routing.inetsim.ports }}
 
 [tor]
 # Route a VM through Tor, requires a local setup of Tor (please refer to our


### PR DESCRIPTION
* for linux samples is useful to be able activate dummy port in `inetsim
is 1 tcp/udp` and in `fakenet-ng is tcp/udp 1337`
* also added support for correct ports forwarding if dummy port
activated