### PR TITLE
Update requirements.txt -

### DIFF
--- a/docs/book/installation/guest_physical/requirements.rst
+++ b/docs/book/installation/guest_physical/requirements.rst
@@ -26,6 +26,9 @@ to download and install the proper packages according to your Python version.
 .. _`official website`: http://www.python.org/getit/
 .. _`Python Pillow`: https://python-pillow.org/
 
+
+*NOTE*: Physical machinery is currently not supported by the new cuckoo agent.  Please use the old cuckoo agent for physical machinery in the meantime.
+
 Additional Software
 ===================
 


### PR DESCRIPTION
Alert users that are following the documentation for installs that include physical machinery to the fact that the new cuckoo agent does not currently support physical machinery & let them know to use old agent. https://github.com/cuckoosandbox/cuckoo/issues/1396