### PR TITLE
Add ability to include whitelist from $CWD aswell

### DIFF
--- a/cuckoo/common/whitelist.py
+++ b/cuckoo/common/whitelist.py
@@ -13,8 +13,11 @@ def is_whitelisted_domain(domain):
         for domain in open(cwd("whitelist", "domain.txt", private=True)):
             domains.add(domain.strip())
 
-        # collect whitelist also from $CWD
-        for domain in open(cwd("whitelist", "domain.txt")):
-            domains.add(domain.strip())
+        # collect whitelist also from $CWD when possible
+        try:
+            for domain in open(cwd("whitelist", "domain.txt")):
+                domains.add(domain.strip())
+        except IOError:
+            pass
 
     return domain in domains

--- a/cuckoo/common/whitelist.py
+++ b/cuckoo/common/whitelist.py
@@ -13,4 +13,8 @@ def is_whitelisted_domain(domain):
         for domain in open(cwd("whitelist", "domain.txt", private=True)):
             domains.add(domain.strip())
 
+        # collect whitelist also from $CWD
+        for domain in open(cwd("whitelist", "domain.txt")):
+            domains.add(domain.strip())
+
     return domain in domains

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -95,9 +95,23 @@ class Pcap(object):
 
     def _build_whitelist(self):
         result = []
-        whitelist_path = cwd("whitelist", "domain.txt", private=True)
-        for line in open(whitelist_path, "rb"):
-            result.append(line.strip())
+
+        result.extend(self._build_whitelist_from_path(cwd("whitelist", "domain.txt", private=True)))
+        # grab whitelist also from $CWD
+        result.extend(self._build_whitelist_from_path(cwd("whitelist", "domain.txt")))
+
+        return result
+
+    def _build_whitelist_from_path(self, path):
+        result = []
+
+        try:
+            for line in open(path, "rb"):
+                result.append(line.strip())
+        except IOError:
+            log.debug("Domain Whitelist file {0} not found or not readable".format(path))
+            return result
+
         return result
 
     def _is_whitelisted(self, conn, hostname):


### PR DESCRIPTION
This PR brings back option to add second custom whitelist via path $CWD/whitelist/domain.txt when available and merges it with built in whitelist from package

Should resolve issues one way or another #1785 #1716 #1465 #948