### PR TITLE
Removed ifconfig from rooter, as ip can deliver the same information

### DIFF
--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -21,7 +21,6 @@ except ImportError:
 from cuckoo.misc import version as __version__
 
 class s(object):
-    ifconfig = None
     service = None
     iptables = None
     ip = None
@@ -46,7 +45,7 @@ def nic_available(interface):
         return False
 
     try:
-        subprocess.check_call([s.ifconfig, interface],
+        subprocess.check_call([s.ip, "link", "show", interface],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
         return True
@@ -305,7 +304,7 @@ handlers = {
     "drop_disable": drop_disable,
 }
 
-def cuckoo_rooter(socket_path, group, ifconfig, service, iptables, ip):
+def cuckoo_rooter(socket_path, group, service, iptables, ip):
     if not HAVE_GRP:
         sys.exit(
             "Could not find the `grp` module, the Cuckoo Rooter is only "
@@ -318,9 +317,6 @@ def cuckoo_rooter(socket_path, group, ifconfig, service, iptables, ip):
             "Note that on CentOS you should provide --service /sbin/service, "
             "rather than using the Ubuntu/Debian default /usr/sbin/service."
         )
-
-    if not ifconfig or not os.path.exists(ifconfig):
-        sys.exit("The `ifconfig` binary is not available, eh?!")
 
     if not iptables or not os.path.exists(iptables):
         sys.exit("The `iptables` binary is not available, eh?!")
@@ -357,7 +353,6 @@ def cuckoo_rooter(socket_path, group, ifconfig, service, iptables, ip):
     os.chmod(socket_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IWGRP)
 
     # Initialize global variables.
-    s.ifconfig = ifconfig
     s.service = service
     s.iptables = iptables
     s.ip = ip

--- a/cuckoo/main.py
+++ b/cuckoo/main.py
@@ -363,13 +363,12 @@ def process(ctx, instance, report, maxcount):
 @main.command()
 @click.argument("socket", type=click.Path(readable=False, dir_okay=False), default="/tmp/cuckoo-rooter", required=False)
 @click.option("-g", "--group", default="cuckoo", help="Unix socket group")
-@click.option("--ifconfig", type=click.Path(exists=True), default="/sbin/ifconfig", help="Path to ifconfig(8)")
 @click.option("--service", type=click.Path(exists=True), default="/usr/sbin/service", help="Path to service(8) for invoking OpenVPN")
 @click.option("--iptables", type=click.Path(exists=True), default="/sbin/iptables", help="Path to iptables(8)")
 @click.option("--ip", type=click.Path(exists=True), default="/sbin/ip", help="Path to ip(8)")
 @click.option("--sudo", is_flag=True, help="Request superuser privileges")
 @click.pass_context
-def rooter(ctx, socket, group, ifconfig, service, iptables, ip, sudo):
+def rooter(ctx, socket, group, service, iptables, ip, sudo):
     """Instantiates the Cuckoo Rooter."""
     init_console_logging(level=ctx.parent.level)
 
@@ -377,7 +376,6 @@ def rooter(ctx, socket, group, ifconfig, service, iptables, ip, sudo):
         args = [
             "sudo", sys.argv[0], "rooter", socket,
             "--group", group,
-            "--ifconfig", ifconfig,
             "--service", service,
             "--iptables", iptables,
             "--ip", ip,
@@ -392,7 +390,7 @@ def rooter(ctx, socket, group, ifconfig, service, iptables, ip, sudo):
             pass
     else:
         try:
-            cuckoo_rooter(socket, group, ifconfig, service, iptables, ip)
+            cuckoo_rooter(socket, group, service, iptables, ip)
         except KeyboardInterrupt:
             print(red("Aborting the Cuckoo Rooter.."))
 


### PR DESCRIPTION
This pull request removes the `ifconfig` utility from the rooter function. The `ip` iutility is required anyways and can do the same job, and `ifconfig` is redundant (and not present on my system, whereas `ip` is).