### PR TITLE
initial support for Proxmox Virtual servers

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -365,6 +365,28 @@ class Config(object):
             },
             "__star__": ("esx", "machines"),
         },
+        "proxmox": {
+            "proxmox": {
+                "username": String("username"),
+                "password": String("password"),
+                "hostname": String("Hostname"),
+                "interface": String("eth1"),
+                "machines": List(String, "analysis1"),
+            },
+            "*": {
+                "__section__": "analysis1",
+                "label": String("cuckoo1"),
+                "platform": String("windows"),
+                "ip": String("192.168.122.101"),
+                "snapshot": String("win_snapshot"),
+                "vmid": String(),
+                "interface": String(),
+                "resultserver_ip": String(),
+                "tags": String(),
+                "osprofile": String(required=False),
+            },
+            "__star__": ("proxmox", "machines"),
+        },
         "kvm": {
             "kvm": {
                 "interface": String("virbr0"),

--- a/cuckoo/core/database.py
+++ b/cuckoo/core/database.py
@@ -92,6 +92,7 @@ class Machine(Base):
                         backref="machine")
     options = Column(JsonTypeList255(), nullable=True)
     interface = Column(String(255), nullable=True)
+    vmid = Column(Integer(), nullable=True)
     snapshot = Column(String(255), nullable=True)
     locked = Column(Boolean(), nullable=False, default=False)
     locked_changed_on = Column(DateTime(timezone=False), nullable=True)
@@ -134,7 +135,7 @@ class Machine(Base):
                 return
         return True
 
-    def __init__(self, name, label, ip, platform, options, interface,
+    def __init__(self, name, label, ip, platform, options, interface, vmid,
                  snapshot, resultserver_ip, resultserver_port):
         self.name = name
         self.label = label
@@ -142,6 +143,7 @@ class Machine(Base):
         self.platform = platform
         self.options = options
         self.interface = interface
+        self.vmid = vmid
         self.snapshot = snapshot
         self.resultserver_ip = resultserver_ip
         self.resultserver_port = resultserver_port
@@ -559,7 +561,7 @@ class Database(object):
             session.close()
 
     @classlock
-    def add_machine(self, name, label, ip, platform, options, tags, interface,
+    def add_machine(self, name, label, ip, platform, options, tags, interface, vmid,
                     snapshot, resultserver_ip, resultserver_port):
         """Add a guest machine.
         @param name: machine id
@@ -584,6 +586,7 @@ class Database(object):
                           platform=platform,
                           options=options,
                           interface=interface,
+                          vmid=vmid,
                           snapshot=snapshot,
                           resultserver_ip=resultserver_ip,
                           resultserver_port=resultserver_port)

--- a/cuckoo/machinery/proxmox.py
+++ b/cuckoo/machinery/proxmox.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2017 Menlo Security
+
+import bs4
+import logging
+import requests
+import socket
+import subprocess
+import wakeonlan.wol
+import xmlrpclib
+
+
+from cuckoo.common.config import config
+from cuckoo.common.exceptions import CuckooCriticalError
+from cuckoo.common.exceptions import CuckooMachineError
+from cuckoo.common.exceptions import CuckooOperationalError
+from cuckoo.common.exceptions import CuckooReportError
+from cuckoo.common.exceptions import CuckooDependencyError
+from cuckoo.common.files import Folders
+from cuckoo.common.objects import Dictionary
+from cuckoo.core.database import Database
+from cuckoo.misc import cwd
+
+from cuckoo.common.abstracts import Machinery
+from proxmoxer import ProxmoxAPI
+
+class Proxmox(Machinery):
+    """Manage Proxmox sandboxes."""
+        
+    def __init__(self):
+        self.options = None
+        self.db = Database()
+        self.vms = {}
+        
+        # Machine table is cleaned to be filled from configuration file
+        # at each start.
+        self.db.clean_machines()
+
+    def _initialize(self, module_name):
+        """Read configuration.
+        @param module_name: module name.
+        """
+        machinery = self.options.get(module_name)
+        
+        
+        for vmname in machinery["machines"]:
+            options = self.options.get(vmname)
+
+            # If configured, use specific network interface for this
+            # machine, else use the default value.
+            if options.get("interface"):
+                interface = options["interface"]
+            else:
+                interface = machinery.get("interface")
+           
+            if options.get("resultserver_ip"):
+                ip = options["resultserver_ip"]
+            else:
+                ip = config("cuckoo:resultserver:ip")
+
+            if options.get("resultserver_port"):
+                port = options["resultserver_port"]
+            else:
+                # The ResultServer port might have been dynamically changed,
+                # get it from the ResultServer singleton. Also avoid import
+                # recursion issues by importing ResultServer here.
+                from cuckoo.core.resultserver import ResultServer
+                port = ResultServer().port
+
+            self.db.add_machine(
+                name=vmname,
+                label=options[self.LABEL],
+                ip=options.ip,
+                platform=options.platform,
+                options=options.get("options", ""),
+                tags=options.tags,
+                interface=interface,
+                snapshot=options.snapshot,
+                vmid=options.vmid,
+                resultserver_ip=ip,
+                resultserver_port=port
+            )
+    
+    
+    def _initialize_check(self):
+        """Ensures that credentials have been entered into the config file.
+        @raise CuckooCriticalError: if no credentials were provided
+        """
+        # TODO This should be moved to a per-machine thing.
+        if not self.options.proxmox.username or not self.options.proxmox.password:
+            raise CuckooCriticalError(
+                "Proxmox credentials are missing, please add it to "
+                "the Proxmox machinery configuration file."
+            )
+        if not self.options.proxmox.hostname:
+            raise CuckooCriticalError(
+                "Proxmox hostname not set"
+            )
+            
+    def login(self):
+      proxmox = ProxmoxAPI(self.options.proxmox.hostname, user=self.options.proxmox.username,
+                     password=self.options.proxmox.password, verify_ssl=False)
+      for node in proxmox.nodes.get():
+        if 'uptime' in node:
+          for vm in proxmox.nodes(node['node']).qemu.get():
+            vmid = str(vm['vmid'])
+            self.vms[vmid] = {}
+            self.vms[vmid]['node'] = node['node']
+            self.vms[vmid]['name'] = vm['name']
+            self.vms[vmid]['status'] = vm['status']
+            print self.vms[vmid]
+      return proxmox
+
+    def start(self, label, task):
+        try:
+            proxmox = self.login()
+            vmid = str(self.db.view_machine_by_label(label).vmid)
+            snapshot = self.db.view_machine_by_label(label).snapshot
+            print "label: %s, task: %s" % (label,task)
+            proxmox.nodes(self.vms[vmid]['node']).qemu(vmid).snapshot(snapshot).rollback.post()
+        except OSError as e:
+            raise CuckooMachineError("oops! couldn't restore VM %s to snapshot %s - %s" % (vmid,snapshot, e) )
+
+    def stop(self, label):
+        try:
+            proxmox = self.login()
+            vmid = str(self.db.view_machine_by_label(label).vmid)
+            print "VMID:-"
+            print self.vms
+            proxmox.nodes(self.vms[vmid]['node']).qemu(vmid).status.stop.post()
+        except OSError as e:
+            raise CuckooMachineError("oops! Couldn't stop VM. %s - %s" % (vmid, e) )
+


### PR DESCRIPTION
This is an initial commit for support of Proxmox Virtual hosts.

https://pve.proxmox.com/wiki/Main_Page

Adding "VMID" to the database to track the VM inside proxmox. 

At the very least the proxmox user must have the following permissions:
- VM.Snapshot
- VM.PowerMgmt

Also need to install "ProxmoxAPI".

