### PR TITLE
Introduce timeout to process

### DIFF
--- a/cuckoo/apps/apps.py
+++ b/cuckoo/apps/apps.py
@@ -306,12 +306,28 @@ def process_task_range(tasks):
         if os.path.isdir(cwd(analysis=task_id)):
             process_task(Dictionary(task))
 
-def process_tasks(instance, maxcount):
+def process_check_stop(count, maxcount, endtime):
+    """Check if we need to stop processing.
+     Options passed by maxcount (-m) or calculated endtime (-t)
+    """
+    if maxcount and count != maxcount:
+        return False
+
+    if endtime and int(time.time()) > endtime:
+        return False
+
+    return True
+
+def process_tasks(instance, maxcount, timeout):
     count = 0
+    endtime = 0
     db = Database()
 
+    if timeout:
+        endtime = int(time.time() + timeout)
+
     try:
-        while not maxcount or count != maxcount:
+        while process_check_stop(count, maxcount, endtime):
             task_id = db.processing_get_task(instance)
 
             # Wait a small while before trying to fetch a new task.

--- a/cuckoo/apps/apps.py
+++ b/cuckoo/apps/apps.py
@@ -310,7 +310,7 @@ def process_check_stop(count, maxcount, endtime):
     """Check if we need to stop processing.
      Options passed by maxcount (-m) or calculated endtime (-t)
     """
-    if maxcount and count > maxcount:
+    if maxcount and count >= maxcount:
         return False
 
     if endtime and int(time.time()) > endtime:

--- a/cuckoo/apps/apps.py
+++ b/cuckoo/apps/apps.py
@@ -310,7 +310,7 @@ def process_check_stop(count, maxcount, endtime):
     """Check if we need to stop processing.
      Options passed by maxcount (-m) or calculated endtime (-t)
     """
-    if maxcount and count != maxcount:
+    if maxcount and count > maxcount:
         return False
 
     if endtime and int(time.time()) > endtime:

--- a/cuckoo/main.py
+++ b/cuckoo/main.py
@@ -319,8 +319,9 @@ def submit(ctx, target, url, options, package, custom, owner, timeout,
 @click.argument("instance", required=False)
 @click.option("-r", "--report", help="Re-generate one or more reports")
 @click.option("-m", "--maxcount", default=0, help="Maximum number of analyses to process")
+@click.option("-t", "--timeout", default=0, help="Maximum timeout to process analyses (in seconds)")
 @click.pass_context
-def process(ctx, instance, report, maxcount):
+def process(ctx, instance, report, maxcount, timeout):
     """Process raw task data into reports."""
     init_console_logging(level=ctx.parent.level)
 
@@ -356,7 +357,7 @@ def process(ctx, instance, report, maxcount):
                 "Initialized instance=%s, ready to process some tasks",
                 instance
             )
-            process_tasks(instance, maxcount)
+            process_tasks(instance, maxcount, timeout)
     except KeyboardInterrupt:
         print(red("Aborting (re-)processing of your analyses.."))
 


### PR DESCRIPTION
This PR introduces timeout option (-t/--timeout) to processing in seconds. 
This can be used for automate restarts on processing and (for example) reload changed signatures/yara-s/whatsoever on live infra. supervisord will be bringing the processing thread up again