### PR TITLE
TagHost Windows guest auxiliary module

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/auxiliary/taghost.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/taghost.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2016 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+import logging
+import os
+import subprocess
+
+from lib.common.abstracts import Auxiliary
+
+log = logging.getLogger(__name__)
+
+NXLOG_CONF = 'C:/Program Files (x86)/nxlog/conf/nxlog.conf'
+HOSTNAME_DUMMY_VAR = 'CUCKOOBOX'
+
+class TagHost(Auxiliary):
+    """
+    A module for rewriting a guests hostname so event logs from a specific
+    analysis run can be easily identified in event logs.
+    """
+    def __init__(self, options={}, analyzer=None):
+        Auxiliary.__init__(self, options, analyzer)
+
+    def rewrite_hostname(self):
+        if 'host_tag' not in self.options:
+            log.info("No tag provided. Leaving guest hostname alone.")
+            return
+
+        # Make sure an NXLog configuration exists
+        if not os.path.exists(NXLOG_CONF):
+            log.error("Couldn't find an NXLog configuration.")
+            return
+
+        try:
+            # Get our tag from the supplied "host_tag" option
+            tag = self.options['host_tag']
+            log.info("Rewriting guest hostname to: %s", tag)
+
+            # Rewrite the dummy variable with the supplied tag
+            lines = []
+            with open(NXLOG_CONF) as infile:
+                for line in infile:
+                    line = line.replace(HOSTNAME_DUMMY_VAR, tag)
+                    lines.append(line)
+            with open(NXLOG_CONF, 'w') as outfile:
+                for line in lines:
+                    outfile.write(line)
+        except Exception as e:
+            log.error("Error rewriting the NXLog config: %s", e)
+            return
+
+        try:
+            # Restart the NXLog service after rewriting the config
+            log.info("Restarting NXLog for good measure.")
+            subprocess.call('net stop nxlog && net start nxlog', shell=True)
+        except Exception as e:
+            log.error("Error restarting NXLog to apply config: %s", e)
+            return
+
+    def start(self):
+        self.rewrite_hostname()
+        return True
+
+    def stop(self):
+        # Stop NXLog at the end of the run so we don't 
+        # leave any stale connections open
+        try:
+            log.info("Stopping NXLog on guest.")
+            subprocess.call('net stop nxlog', shell=True)
+        except:
+            log.error("Error attempting to stop NXLog on the guest.")
+        return True


### PR DESCRIPTION
Adding in a Windows guest auxiliary module for "tagging" Windows event logs from analysis runs.

It requires NXLog to be installed on the guest and makes use of a dummy hostname variable in the NXLog configuration which it rewrites with a tag the user can supply via the `host_tag` analysis option.

Simple example NXLog configuration:
```
define ROOT C:\Program Files (x86)\nxlog

Moduledir %ROOT%\modules
CacheDir %ROOT%\data
Pidfile %ROOT%\data\nxlog.pid
SpoolDir %ROOT%\data
LogFile %ROOT%\data\nxlog.log

<Extension _json>
    Module    xm_json
</Extension>

<Extension _exec>
    Module    xm_exec
</Extension>

<Input eventlog>
    Module    im_msvistalog
    Exec    $Hostname = "CUCKOOBOX";\
            to_json();
</Input>

<Output sender>
    Module    om_tcp
    Host        192.168.56.1
    Port        514
</Output>

<Route primary>
    Path    eventlog => sender
</Route>
```

The important piece for the module is the `CUCKOOBOX` dummy value. A user can supply an option to the analysis such as `host_tag=tag123`, the module will rewrite `CUCKOOBOX` with `tag123`, the module will restart the NXLog service to apply the new configuration, and now all Windows event logs going forward will contain a hostname value of `tag123`. This makes it easy to distinguish event logs for particular analysis runs by the supplied tag.

I wasn't quite sure where to stick documentation for this module since guest auxiliary modules don't seem to have a specific home, or if and where to include the example NXLog configuration, so let me know if there's a good place for either of those things.