### PR TITLE
Launching the web interface faster and in a safer way.

### DIFF
--- a/cuckoo/main.py
+++ b/cuckoo/main.py
@@ -545,7 +545,7 @@ def web(ctx, args, host, port, uwsgi, nginx):
 
     try:
         execute_from_command_line(
-            ("cuckoo", "runserver", "%s:%d" % (host, port))
+            ("cuckoo", "runserver", "%s:%d" % (host, port), "--noreload")
             if not args else
             ("cuckoo",) + args
         )


### PR DESCRIPTION
By default, django's web server forks itself to create another process that constantly scans the source code for changes, and than restarts the server.
This sometimes makes the launching of the web interface very slow + has a small potential to cause loss of state.
Passing a `--noreload` argument to django prevents this behavior.