### PR TITLE
Log errors when creating tempfiles

### DIFF
--- a/cuckoo/core/guest.py
+++ b/cuckoo/core/guest.py
@@ -298,7 +298,13 @@ class GuestManager(object):
         session = requests.Session()
         session.trust_env = False
         session.proxies = None
-        r = session.get(url, *args, **kwargs)
+
+        try:
+            r = session.get(url, *args, **kwargs)
+        except requests.ConnectionError:
+            raise CuckooGuestError("Agent failed without error status, please try upgrading to the "
+                                   "latest version of agent.py and notify us if the issue persists.")
+
         do_raise and r.raise_for_status()
         return r
 
@@ -308,7 +314,13 @@ class GuestManager(object):
         session = requests.Session()
         session.trust_env = False
         session.proxies = None
-        r = session.post(url, *args, **kwargs)
+
+        try:
+            r = session.post(url, *args, **kwargs)
+        except requests.ConnectionError:
+            raise CuckooGuestError("Agent failed without error status, please try upgrading to the "
+                                   "latest version of agent.py and notify us if the issue persists.")
+
         r.raise_for_status()
         return r
 

--- a/cuckoo/data/agent/agent.py
+++ b/cuckoo/data/agent/agent.py
@@ -247,7 +247,11 @@ def do_mktemp():
     prefix = request.form.get("prefix", "tmp")
     dirpath = request.form.get("dirpath")
 
-    fd, filepath = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dirpath)
+    try:
+        fd, filepath = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dirpath)
+    except:
+        return json_exception("Error creating temporary file")
+    
     os.close(fd)
 
     return json_success("Successfully created temporary file",
@@ -259,7 +263,11 @@ def do_mkdtemp():
     prefix = request.form.get("prefix", "tmp")
     dirpath = request.form.get("dirpath")
 
-    dirpath = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dirpath)
+    try:
+        dirpath = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dirpath)
+    except:
+        return json_exception("Error creating temporary directory")
+
     return json_success("Successfully created temporary directory",
                         dirpath=dirpath)
 


### PR DESCRIPTION
Fixes issue where agent silently fails on creating temp files/directories (usually due to permissions).
See https://github.com/cuckoosandbox/cuckoo/issues/1893 and https://github.com/cuckoosandbox/cuckoo/issues/1876.