### PR TITLE
Fix Suricata file log parsing

### DIFF
--- a/cuckoo/processing/suricata.py
+++ b/cuckoo/processing/suricata.py
@@ -239,7 +239,7 @@ class Suricata(Processing):
                 referer = None
 
             self.results["files"].append({
-                "id": int(filepath.split(".", 1)[-1]),
+                "id": int(filepath.split(".")[-1]),
                 "filesize": event["size"],
                 "filename": os.path.basename(event["filename"]),
                 "hostname": event.get("http_host"),


### PR DESCRIPTION
Fix error

Traceback (most recent call last):
  File "/home/cuckoo/dev/cuckoo/cuckoo/core/plugins.py", line 240, in process
    data = current.run()
  File "/home/cuckoo/dev/cuckoo/cuckoo/processing/suricata.py", line 290, in run
    self.parse_files()
  File "/home/cuckoo/dev/cuckoo/cuckoo/processing/suricata.py", line 242, in parse_files
    "id": int(filepath.split(".", 1)[-1]),
ValueError: invalid literal for int() with base 10: 'cuckoo/storage/analyses/1024/suricata/files/file.1'
 master (#1)