### PR TITLE
Remove artifacts from older installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
         psql -U postgres -c "CREATE DATABASE cuckootestimport"
         psql -U postgres cuckootestimport <tests/files/sql/11pg.sql >/dev/null
         pip install psycopg2 mysql-python m2crypto==0.24.0 weasyprint
+        rm -v /home/travis/build/cuckoosandbox/cuckoo/cuckoo/private/.cwd
     else
         brew update || brew update
         brew install libmagic cairo pango mongodb


### PR DESCRIPTION
It seems that the .cwd file is no more created and without it the tests should fail.