### PR TITLE
Make testing more developer friendly - cleanup after successfull tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
         psql -U postgres -c "CREATE DATABASE cuckootestimport"
         psql -U postgres cuckootestimport <tests/files/sql/11pg.sql >/dev/null
         pip install psycopg2 mysql-python m2crypto==0.24.0 weasyprint
-        rm -v /home/travis/build/cuckoosandbox/cuckoo/cuckoo/private/.cwd
     else
         brew update || brew update
         brew install libmagic cairo pango mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
         psql -U postgres -c "CREATE DATABASE cuckootestimport"
         psql -U postgres cuckootestimport <tests/files/sql/11pg.sql >/dev/null
         pip install psycopg2 mysql-python m2crypto==0.24.0 weasyprint
+        rm -v /home/travis/build/cuckoosandbox/cuckoo/cuckoo/private/.cwd
     else
         brew update || brew update
         brew install libmagic cairo pango mongodb

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -339,23 +339,23 @@ class TestProcessing(object):
             "category": "file",
         })
 
-        fd, filepath = tempfile.mkstemp()
-        os.write(fd, "ABCDEFGH\n"*0x1000)
-        os.close(fd)
+        with tempfile.NamedTemporaryFile() as fd:
+            filepath = fd.name
+            fd.write("ABCDEFGH\n"*0x1000)
 
-        s.file_path = filepath
-        assert len(s.run()) == s.MAX_STRINGCNT
+            s.file_path = filepath
+            assert len(s.run()) == s.MAX_STRINGCNT
 
-        fd, filepath = tempfile.mkstemp()
-        os.write(fd, ("%s\n" % ("A"*0x1000)) * 200)
-        os.close(fd)
+        with tempfile.NamedTemporaryFile() as fd:
+            filepath = fd.name
+            fd.write(("%s\n" % ("A"*0x1000)) * 200)
 
-        s.file_path = filepath
-        strings = s.run()
-        assert len(strings) == 200
-        assert len(strings[0]) == s.MAX_STRINGLEN
-        assert len(strings[42]) == s.MAX_STRINGLEN
-        assert len(strings[199]) == s.MAX_STRINGLEN
+            s.file_path = filepath
+            strings = s.run()
+            assert len(strings) == 200
+            assert len(strings[0]) == s.MAX_STRINGLEN
+            assert len(strings[42]) == s.MAX_STRINGLEN
+            assert len(strings[199]) == s.MAX_STRINGLEN
 
     @mock.patch("cuckoo.processing.screenshots.log")
     def test_screenshot_tesseract(self, p):


### PR DESCRIPTION
Running tests is essential for the developement process. After some hours of developement my hdd was filled with gigabytes of data. From pydoc [1]:

> The user of mkdtemp() is responsible for deleting the temporary directory and its contents when done with it.

This is the first patchset in which we start to cleanup after successfull tests.
Reporduce:
- set TMPDIR to other directory than /tmp for testing
- run the tests
- `$> du -sh /path/to/the/tmp/dir`



[1] https://docs.python.org/2/library/tempfile.html#tempfile.mkdtemp