### PR TITLE
LnkShortcut: check format error

### DIFF
--- a/cuckoo/processing/static.py
+++ b/cuckoo/processing/static.py
@@ -808,7 +808,12 @@ class LnkShortcut(object):
                 ret["attrs"].append(self.attrs[x])
 
         offset = 78 + self.read_uint16(76)
-        off = LnkEntry.from_buffer_copy(buf[offset:offset+28])
+        if len(buf) >= offset + 28:
+            off = LnkEntry.from_buffer_copy(buf[offset:offset + 28])
+        else:
+            log.warning("Provided .lnk file is corrupted or incomplete.")
+            return
+
 
         # Local volume.
         if off.volume_flags & 1:


### PR DESCRIPTION
```
[cuckoo.core.plugins] ERROR: Failed to run the processing module "Static" for task #642855:
Traceback (most recent call last):
  File "cuckoo/cuckoo/core/plugins.py", line 243, in process
    data = current.run()
  File "cuckoo/cuckoo/processing/static.py", line 1103, in run
    static["lnk"] = LnkShortcut(f.file_path).run()
  File "cuckoo/cuckoo/processing/static.py", line 811, in run
    off = LnkEntry.from_buffer_copy(buf[offset:offset + 28])
ValueError: Buffer size too small (0 instead of at least 28 bytes)
```