### PR TITLE
Fix resubmit

### DIFF
--- a/cuckoo/web/controllers/submission/routes.py
+++ b/cuckoo/web/controllers/submission/routes.py
@@ -78,7 +78,7 @@ class SubmissionRoutes(object):
             ], submit_manager.translate_options_to(task.options))
         else:
             file_path = binary_filepath(task_id) if not os.path.exists(task.target) else task.target
-            if not os.path.exists(file_path):
+            if file_path and not os.path.exists(file_path):
                 return view_error(
                     request, "The file you're trying to resubmit "
                     "no longer exists. Please resubmit it altogether!"

--- a/cuckoo/web/controllers/submission/routes.py
+++ b/cuckoo/web/controllers/submission/routes.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from cuckoo.common.exceptions import CuckooOperationalError
 from cuckoo.core.database import Database
 from cuckoo.core.submit import SubmitManager
-from cuckoo.web.utils import view_error, render_template, dropped_filepath
+from cuckoo.web.utils import view_error, render_template, dropped_filepath, binary_filepath
 
 log = logging.getLogger(__name__)
 submit_manager = SubmitManager()
@@ -77,7 +77,8 @@ class SubmissionRoutes(object):
                 task.target,
             ], submit_manager.translate_options_to(task.options))
         else:
-            if not os.path.exists(task.target):
+            file_path = binary_filepath(task_id) if not os.path.exists(task.target) else task.target
+            if not os.path.exists(file_path):
                 return view_error(
                     request, "The file you're trying to resubmit "
                     "no longer exists. Please resubmit it altogether!"
@@ -87,7 +88,7 @@ class SubmissionRoutes(object):
             # analyses of type "archive".
             submit_id = submit_manager.pre("files", [{
                 "name": os.path.basename(task.target),
-                "data": open(task.target, "rb"),
+                "data": open(file_path, "rb"),
             }], submit_manager.translate_options_to(task.options))
 
         return redirect("submission/pre", submit_id=submit_id)

--- a/cuckoo/web/controllers/submission/routes.py
+++ b/cuckoo/web/controllers/submission/routes.py
@@ -78,7 +78,7 @@ class SubmissionRoutes(object):
             ], submit_manager.translate_options_to(task.options))
         else:
             file_path = binary_filepath(task_id) if not os.path.exists(task.target) else task.target
-            if file_path and not os.path.exists(file_path):
+            if not file_path or not os.path.exists(file_path):
                 return view_error(
                     request, "The file you're trying to resubmit "
                     "no longer exists. Please resubmit it altogether!"

--- a/cuckoo/web/utils.py
+++ b/cuckoo/web/utils.py
@@ -121,6 +121,16 @@ def dropped_filepath(task_id, sha1):
         if dropped["sha1"] == sha1:
             return dropped["path"]
 
+def binary_filepath(task_id):
+    record = mongo.db.analysis.find_one({
+        "info.id": int(task_id)
+    })
+
+    if not record or not record["target"]["file"]:
+        return
+
+    return record["target"]["file"]["path"]
+
 def normalize_task(task):
     if task["category"] == "file":
         task["target"] = os.path.basename(task["target"])


### PR DESCRIPTION
This fixes an issue in resubmit.
The filepath taken is the temporary file used to submit.
Once analyized another copy is held in the analysis folder. 
That one remains available to download.

Fix #1644 for sure
Fix #1370 also,