### PR TITLE
elasticsearch and mongodb reporting avoid doubles

### DIFF
--- a/cuckoo/reporting/elasticsearch.py
+++ b/cuckoo/reporting/elasticsearch.py
@@ -86,6 +86,19 @@ class ElasticSearch(Report):
         }
         return header
 
+    def delete_report(self, task_id):
+        query = {
+              'query': { 'match' : { 'task_id' : task_id}},
+        }
+        elastic.client.delete_by_query(
+            index=self.dated_index, doc_type=self.report_type,
+            body=query
+        )
+        elastic.client.delete_by_query(
+            index=self.dated_index, doc_type=self.call_type,
+            body=query
+        )
+
     def do_index(self, obj):
         base_document = self.get_base_document()
 
@@ -215,6 +228,7 @@ class ElasticSearch(Report):
         if procmemory:
             doc["procmemory"] = procmemory
 
+        self.delete_report(doc["info"]["id"])
         self.do_index(doc)
 
         # Index the API calls.

--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -259,5 +259,7 @@ class MongoDB(Report):
 
             report["procmon"] = procmon
 
+        # Remove previous reports if any
+        self.db.analysis.remove({"info.id" : report["info"]["id"]})
         # Store the report and retrieve its object id.
         self.db.analysis.save(report)

--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -274,6 +274,3 @@ class MongoDB(Report):
 
         # Store the report and retrieve its object id.
         self.db.analysis.save(report)
-
-#    def clean_report(self, report_id):
-

--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -260,6 +260,20 @@ class MongoDB(Report):
             report["procmon"] = procmon
 
         # Remove previous reports if any
-        self.db.analysis.remove({"info.id" : report["info"]["id"]})
+        previous = self.db.analysis.find({"info.id" : report["info"]["id"]})
+        for preport in previous:
+            if "behavior" in preport and "processes" in preport["behavior"]:
+               for prev_process in preport["behavior"]["processes"]:
+                   for callchunk in prev_process["calls"]:
+                       self.db.calls.remove({ "_id" : callchunk })
+            if "procmon" in preport:
+               for prev_procmon in preport["procmon"]:
+                   self.db.procmon.remove({ "_id" : prev_procmon })
+
+        self.db.analysis.remove({ "info.id" : report["info"]["id"] })
+
         # Store the report and retrieve its object id.
         self.db.analysis.save(report)
+
+#    def clean_report(self, report_id):
+

--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -263,12 +263,12 @@ class MongoDB(Report):
         previous = self.db.analysis.find({"info.id" : report["info"]["id"]})
         for preport in previous:
             if "behavior" in preport and "processes" in preport["behavior"]:
-               for prev_process in preport["behavior"]["processes"]:
-                   for callchunk in prev_process["calls"]:
-                       self.db.calls.remove({ "_id" : callchunk })
+               for process in preport["behavior"]["processes"]:
+                   for chunk_id in process["calls"]:
+                       self.db.calls.remove({ "_id" : chunk_id })
             if "procmon" in preport:
-               for prev_procmon in preport["procmon"]:
-                   self.db.procmon.remove({ "_id" : prev_procmon })
+               for procmon_id in preport["procmon"]:
+                   self.db.procmon.remove({ "_id" : procmon_id })
 
         self.db.analysis.remove({ "info.id" : report["info"]["id"] })
 


### PR DESCRIPTION
This fix ensures that previous analysis results get deleted before saving new items.
After applying one can reprocess its reports to clean existing duplicates.