### PR TITLE
Detect compatible browsers.

### DIFF
--- a/cuckoo/web/src/scripts/app.js
+++ b/cuckoo/web/src/scripts/app.js
@@ -135,15 +135,22 @@ class CuckooWeb {
             console.log("err: " + data);
         });
 
-    }
+ }   
 
     // returns true if the client browser is in the
     // recommended browser list.
     static isRecommendedBrowser() {
 
+	// Chromium compatible (Chrome, Opera, Vivaldi, etc.) or Firefox-based.
+        var isRecommended = (bowser.blink || bowser.gecko);
+	if(isRecommended) {
+                return {
+                    recommended: isRecommended,
+                    browser: bowser.name
+                };
+        }
+	
         var recommended = ['firefox', 'chrome', 'webkit', 'chromium', 'opera'];
-        var isRecommended = false;
-
         for(var recommendation in recommended) {
             if(bowser[recommended[recommendation]]) {
                 isRecommended = true;

--- a/cuckoo/web/src/scripts/app.js
+++ b/cuckoo/web/src/scripts/app.js
@@ -134,8 +134,7 @@ class CuckooWeb {
         }, function (data) {
             console.log("err: " + data);
         });
-
- }   
+    }
 
     // returns true if the client browser is in the
     // recommended browser list.


### PR DESCRIPTION
Treat Chromium compatible (Chrome, Opera, Vivaldi, etc.) or Firefox-based browsers as supported ones.

It does not check browser versions though, so it will be confusing in case of the old Opera for example (`<= 12.x`).