### PR TITLE
Api tasks list sample

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -210,7 +210,9 @@ def tasks_create_submit():
 @app.route("/v1/tasks/list/<int:limit>")
 @app.route("/tasks/list/<int:limit>/<int:offset>")
 @app.route("/v1/tasks/list/<int:limit>/<int:offset>")
-def tasks_list(limit=None, offset=None):
+@app.route("/tasks/list/sample/<int:sample_id>")
+@app.route("/v1/tasks/list/sample/<int:sample_id>")
+def tasks_list(limit=None, offset=None, sample_id=None):
     response = {}
 
     response["tasks"] = []
@@ -227,7 +229,8 @@ def tasks_list(limit=None, offset=None):
     tasks = db.list_tasks(
         limit=limit, details=True, offset=offset,
         completed_after=completed_after, owner=owner,
-        status=status, order_by=Task.completed_on.asc()
+        status=status, sample_id=sample_id,
+        order_by=Task.completed_on.asc()
     )
 
     for row in tasks:

--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -210,8 +210,7 @@ def tasks_create_submit():
 @app.route("/v1/tasks/list/<int:limit>")
 @app.route("/tasks/list/<int:limit>/<int:offset>")
 @app.route("/v1/tasks/list/<int:limit>/<int:offset>")
-@app.route("/tasks/list/sample/<int:sample_id>")
-@app.route("/v1/tasks/list/sample/<int:sample_id>")
+@app.route("/tasks/sample/<int:sample_id>")
 def tasks_list(limit=None, offset=None, sample_id=None):
     response = {}
 

--- a/docs/book/usage/api.rst
+++ b/docs/book/usage/api.rst
@@ -139,6 +139,8 @@ each one. For details click on the resource name.
 | ``GET`` :ref:`tasks_list`           | Returns the list of tasks stored in the internal Cuckoo database.                                                |
 |                                     | You can optionally specify a limit of entries to return.                                                         |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
+| ``GET`` :ref:`tasks_sample`         | Returns the list of tasks stored in the internal Cuckoo database for a given sample.                             |
++-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_view`           | Returns the details on the task assigned to the specified ID.                                                    |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_reschedule`     | Reschedule a task assigned to the specified ID.                                                                  |
@@ -455,6 +457,63 @@ Returns list of tasks.
 
 * ``limit`` *(optional)* *(int)* - maximum number of returned tasks
 * ``offset`` *(optional)* *(int)* - data offset
+
+**Status codes**:
+
+* ``200`` - no error
+
+.. _tasks_sample:
+
+/tasks/sample
+-----------
+
+**GET /tasks/sample/** *(int: sample_id)* **/
+
+Returns list of tasks for sample.
+
+**Example request**.
+
+.. code-block:: bash
+
+    curl http://localhost:8090/tasks/sample/1
+
+**Example response**.
+
+.. code-block:: json
+
+    {
+        "tasks": [
+            {
+                "category": "file",
+                "machine": null,
+                "errors": [],
+                "target": "/tmp/malware.exe",
+                "package": null,
+                "sample_id": 1,
+                "guest": {},
+                "custom": null,
+                "owner": "",
+                "priority": 1,
+                "platform": null,
+                "options": null,
+                "status": "pending",
+                "enforce_timeout": false,
+                "timeout": 0,
+                "memory": false,
+                "tags": [
+                            "32bit",
+                            "acrobat_6",
+                        ],
+                "id": 2,
+                "added_on": "2012-12-19 14:18:25",
+                "completed_on": null
+            }
+        ]
+    }
+
+**Parameters**:
+
+* ``sample_id`` *(required)* *(int)* - sample id to list tasks for
 
 **Status codes**:
 


### PR DESCRIPTION
Added support for listing tasks for a sample. Requires just a small change to existing tasks list function.

Is this something you would consider including?

Some notes:
* I had trouble getting the unit testing to work, so I have not added a unit test.
* Not sure if the "/v1/" route should also have been there, but assumed that was a reference to Cuckoo 1.*.