### PR TITLE
Removes unused and broken variable

### DIFF
--- a/cuckoo/web/templates/analysis/pages/behavior/partials/_process.html
+++ b/cuckoo/web/templates/analysis/pages/behavior/partials/_process.html
@@ -3,7 +3,7 @@
     <p>
       <a href="#">
         {{ process.process_name }}
-        <script type="application/json">{ "name": "{{ process.process_name }}", "pid": "{{ process.pid }}","ppid": "{{ process.ppid }}", "pages": "{{ process.calls|length }}" }</script>
+        <script type="application/json">{ "name": "{{ process.process_name }}", "pid": "{{ process.pid }}","ppid": "{{ process.ppid }}"}</script>
       </a>
       <em><i data-toggle="tooltip" title="{{ process.command_line }}" class="fa fa-eye"></i>{{ process.command_line }}</em>
     </p>


### PR DESCRIPTION
process.calls is an invalid variable in this context, because `_tree.html` template is passing process based on `report.analysis.behavior.processtree` items, which does not actually contain `calls` attribute. `calls` exists and is populated in another piece of the report, but not under `processtree`. 
The pagination still functions and is handled elsewhere, so I don't believe this piece of JSON attribute is actually used anywhere.

Note the error only shows up with DEBUG = True prior to this change, because otherwise the invalid variable will automatically be replaced/handled by django.