### PR TITLE
Add iptables rule to fix the source IP on inetsim responses

### DIFF
--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -197,6 +197,9 @@ def inetsim_enable(ipaddr, inetsim_ip, machinery_iface, resultserver_port):
     dns_forward("-A", ipaddr, inetsim_ip)
     forward_enable(machinery_iface, machinery_iface, ipaddr)
 
+    run(s.iptables, "-t", "nat", "-A", "POSTROUTING", "--source", ipaddr,
+        "-o", machinery_iface, "--destination", inetsim_ip, "-j", "MASQUERADE")
+
     run(s.iptables, "-A", "OUTPUT", "-s", ipaddr, "-j", "DROP")
 
 
@@ -218,6 +221,9 @@ def inetsim_disable(ipaddr, inetsim_ip, machinery_iface, resultserver_port):
 
     dns_forward("-D", ipaddr, inetsim_ip)
     forward_disable(machinery_iface, machinery_iface, ipaddr)
+
+    run(s.iptables, "-t", "nat", "-D", "POSTROUTING", "--source", ipaddr,
+        "-o", machinery_iface, "--destination", inetsim_ip, "-j", "MASQUERADE")
 
     run(s.iptables, "-D", "OUTPUT", "-s", ipaddr, "-j", "DROP")
 


### PR DESCRIPTION
The proposed updates to the inetsim_enable and inetsim_disable functions add an iptables masquerade rule to ensure the correct source IP is put back into redirected packets sent back from the inetsim host. Without this additional rule responses from inetsim will contain the IP address of the inetsim host as the source. Since the IP of the inetsim VM doesn't match the destination IP of the initial request Windows 7 will ignore it. 

The masquerade rule ensures that the source of the response matches the destination of the initial request (i.e. if the Windows host sends a DNS request to 8.8.8.8, the request will be redirected towards the inetsim host, inetsim will send back a DNS response but the source fo this response will be correctly set to 8.8.8.8).

A more detailed discussion can be found at https://github.com/cuckoosandbox/cuckoo/issues/1619#issuecomment-361617430 