### PR TITLE
Allow Reporting, Auxiliary, and Processing plugins to specify their configuration instead of having to modifying Config.configuration in config.py

### DIFF
--- a/cuckoo/common/abstracts.py
+++ b/cuckoo/common/abstracts.py
@@ -39,6 +39,10 @@ class Auxiliary(object):
         self.options = None
 
     @classmethod
+    def get_config(cls):
+        pass
+
+    @classmethod
     def init_once(cls):
         pass
 
@@ -610,6 +614,10 @@ class Processing(object):
         self.machine = None
         self.options = None
         self.results = {}
+
+    @classmethod
+    def get_config(cls):
+        pass
 
     @classmethod
     def init_once(cls):
@@ -1216,6 +1224,10 @@ class Report(object):
         self.reports_path = ""
         self.task = None
         self.options = None
+
+    @classmethod
+    def get_config(cls):
+        pass
 
     @classmethod
     def init_once(cls):

--- a/cuckoo/core/startup.py
+++ b/cuckoo/core/startup.py
@@ -411,3 +411,19 @@ def init_routing():
         if config("routing:routing:auto_rt"):
             rooter("flush_rttable", rt_table)
             rooter("init_rttable", rt_table, interface)
+
+def update_config():
+    """Update the Config.configuration object to have configuration info
+    from plugins."""
+
+    categories = (
+        "auxiliary", "processing", "reporting",
+    )
+
+    for category in categories:
+        config_section = Config.configuration[category]
+        for module in cuckoo.plugins[category]:
+            module_config = module.get_config()
+            if module_config:
+                config_section.update(module_config)
+

--- a/cuckoo/main.py
+++ b/cuckoo/main.py
@@ -37,8 +37,6 @@ from cuckoo.misc import (
     Pidfile, mkdir
 )
 
-logging.basicConfig(level=logging.DEBUG)
-
 log = logging.getLogger("cuckoo")
 
 def cuckoo_create(username=None, cfg=None, quiet=False):

--- a/cuckoo/main.py
+++ b/cuckoo/main.py
@@ -30,12 +30,14 @@ from cuckoo.core.scheduler import Scheduler
 from cuckoo.core.startup import (
     check_configs, init_modules, check_version, init_logfile, init_logging,
     init_console_logging, init_tasks, init_yara, init_binaries, init_rooter,
-    init_routing
+    init_routing, update_config
 )
 from cuckoo.misc import (
     cwd, load_signatures, getuser, decide_cwd, drop_privileges, is_windows,
     Pidfile, mkdir
 )
+
+logging.basicConfig(level=logging.DEBUG)
 
 log = logging.getLogger("cuckoo")
 
@@ -221,6 +223,10 @@ def main(ctx, debug, quiet, nolog, maxcount, user, cwd):
         level = logging.INFO
 
     ctx.level = level
+
+    # Update the Config.configuration object to have configuration info
+    # from plugins.
+    update_config()
 
     # A subcommand will be invoked, so don't run Cuckoo itself.
     if ctx.invoked_subcommand:


### PR DESCRIPTION
Changes to allow Reporting, Auxiliary, and Processing plugin developers to specify their configuration definitions instead of having to modify Config.configuration in config.py. Please see https://github.com/cuckoosandbox/cuckoo/issues/2057 and https://github.com/cuckoosandbox/cuckoo/issues/1580 for background on the issue resolved with this change. 

This is just a initial idea to see if the Cuckoo team thinks this is the right track. I just wanted to get the ball rolling with the Cuckoo team before making more changes. The items that I think need to be added still are:
- Validation of the data returned by get_config() before adding it to "Config.configuration".
- Unit tests in test_startup.py, maybe test_config.py, and any where else the Cuckoo team would recommend. 

Thanks for any feedback!

