### PR TITLE
Accept '.url' files

### DIFF
--- a/cuckoo/data/analyzer/windows/lib/core/packages.py
+++ b/cuckoo/data/analyzer/windows/lib/core/packages.py
@@ -75,7 +75,7 @@ def choose_package(file_type, file_name, exports):
         return "ps1"
     elif file_name.endswith((".wsf", ".wsc")):
         return "wsf"
-    elif "HTML" in file_type or file_name.endswith((".htm", ".html", ".hta", ".mht", ".mhtml")):
+    elif "HTML" in file_type or file_name.endswith((".htm", ".html", ".hta", ".mht", ".mhtml",".url")):
         return "ie"
     else:
         return "generic"

--- a/cuckoo/data/analyzer/windows/modules/packages/ie.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/ie.py
@@ -117,7 +117,7 @@ class IE(Package):
 
         # If it's a HTML file, force an extension, or otherwise Internet
         # Explorer will open it as a text file or something else non-html.
-        if os.path.exists(target) and not target.endswith((".htm", ".html", ".mht", ".mhtml")):
+        if os.path.exists(target) and not target.endswith((".htm", ".html", ".mht", ".mhtml",".url")):
             os.rename(target, target + ".html")
             target += ".html"
             log.info("Submitted file is missing extension, adding .html")


### PR DESCRIPTION
Added .url to file extensions for IE

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
added the '.url' extension to packages.py & ie.py 
##### The goal of my change is:
analysis of .url files
##### What I have tested about my change is:
Tested change on Ubuntu 16.04 with a Windows 7 64bit & 32bit VM through VSphere config