### PR TITLE
Disable SmartScreen in IE

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/packages/ie.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/ie.py
@@ -94,6 +94,22 @@ class IE(Package):
                 "CheckExeSignatures": "no",
             },
         ],
+        [
+            HKEY_LOCAL_MACHINE,
+            "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer",
+            {
+                # Disable SmartScreen Windows 8
+                "SmartScreenEnabled": "Off"
+            }
+        ],
+        [
+            HKEY_CURRENT_USER,
+            "Software\\Microsoft\\Internet Explorer\\PhishingFilter",
+            {
+                # Disable SmartScreen Filter Windows 7
+                "EnabledV9": 0
+            }
+        ],
     ]
 
     def setup_proxy(self, proxy_host):


### PR DESCRIPTION
New registry keys added to disable smart screen filter.

Allows for more accurate URL analysis.

:wink:

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Registry keys in ie.py 

##### The goal of my change is:
To disable smart screen for url jobs

##### What I have tested about my change is:
Tested on urls that cause smart screen to block site and they now are unblocked
