### PR TITLE
Ensure socket is closed after connection test

### DIFF
--- a/cuckoo/core/guest.py
+++ b/cuckoo/core/guest.py
@@ -8,6 +8,8 @@ import io
 import json
 import logging
 import os
+from contextlib import closing
+
 import requests
 import socket
 import time
@@ -336,8 +338,9 @@ class GuestManager(object):
 
         while db.guest_get_status(self.task_id) == "starting":
             try:
-                socket.create_connection((self.ipaddr, self.port), 1).close()
-                break
+                with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+                    if sock.connect_ex((self.ipaddr, self.port)) == 0:
+                        break
             except socket.timeout:
                 log.debug("%s: not ready yet", self.vmid)
             except socket.error:


### PR DESCRIPTION
##### What I have added/changed is:
Ensure socket is closed after connection test against guest

##### The goal of my change is:
While doing mass analysis sometimes sandbox VM hangs. 
If that happens, guest initialization will hangs and the guest stops without any log or exception.
I try to ensure every works are well used during mass analysis.

##### What I have tested about my change is:
Doing analysis over 10,000 samples with 300+ guest vm after this change.
No guest hangs after this change.