### PR TITLE
Create _psxview.html

### DIFF
--- a/cuckoo/web/templates/analysis/pages/memory/_psxview.html
+++ b/cuckoo/web/templates/analysis/pages/memory/_psxview.html
@@ -26,17 +26,3 @@
     {% endfor %}
     </tbody>
 </table>
-
-
-
-
-
-"process_name": str(process.ImageFileName),
-                "process_id": int(process.UniqueProcessId),
-                "pslist": str(offset in ps_sources["pslist"]),
-                "psscan": str(offset in ps_sources["psscan"]),
-                "thrdproc": str(offset in ps_sources["thrdproc"]),
-                "pspcid": str(offset in ps_sources["pspcid"]),
-                "csrss": str(offset in ps_sources["csrss"]),
-                "session": str(offset in ps_sources["session"]),
-                "deskthrd": str(offset in ps_sources["deskthrd"]),

--- a/cuckoo/web/templates/analysis/pages/memory/_psxview.html
+++ b/cuckoo/web/templates/analysis/pages/memory/_psxview.html
@@ -1,0 +1,42 @@
+<table class="cuckoo-table__fullscreen">
+    <thead>
+        <tr>
+            <th>process_id</th>
+            <th>pslist</th>
+            <th>psscan</th>
+            <th>thrdproc</th>
+            <th>pspcid</th>
+            <th>csrss</th>
+            <th>sessions</th>
+            <th>deskthrd</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for row in report.analysis.memory.psxview.data|volsort %}
+        <tr>
+            <td class="{{ row.class_ }}">{{row.process_id}}</td>
+            <td class="{{ row.class_ }}">{{row.pslist}}</td>
+            <td class="{{ row.class_ }}">{{row.psscan}}</td>
+            <td class="{{ row.class_ }}">{{row.thrdproc}}</td>
+            <td class="{{ row.class_ }}">{{row.pspcid}}</td>
+            <td class="{{ row.class_ }}">{{row.csrss}}</td>
+            <td class="{{ row.class_ }}">{{row.session}}</td>
+            <td class="{{ row.class_ }}">{{row.deskthrd}}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+
+
+
+
+"process_name": str(process.ImageFileName),
+                "process_id": int(process.UniqueProcessId),
+                "pslist": str(offset in ps_sources["pslist"]),
+                "psscan": str(offset in ps_sources["psscan"]),
+                "thrdproc": str(offset in ps_sources["thrdproc"]),
+                "pspcid": str(offset in ps_sources["pspcid"]),
+                "csrss": str(offset in ps_sources["csrss"]),
+                "session": str(offset in ps_sources["session"]),
+                "deskthrd": str(offset in ps_sources["deskthrd"]),


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
psxview volatility plugin is well coded as python and stored in databases but not shown in web interface because html file not exist... so i added it and works fine .

##### The goal of my change is:
show psxview volatility plugin in cuckoo web interface 

##### What I have tested about my change is:

the psxview info shown sucessfully
