### PR TITLE
add support to provide banned sids when checking suricata

### DIFF
--- a/cuckoo/common/abstracts.py
+++ b/cuckoo/common/abstracts.py
@@ -1128,13 +1128,14 @@ class Signature(object):
                                  regex=regex,
                                  all=all)
 
-    def check_suricata_alerts(self, pattern):
+    def check_suricata_alerts(self, pattern, banned_sids=[]):
         """Check for pattern in Suricata alert signature
         @param pattern: string or expression to check for.
         @return: True/False
         """
         for alert in self.get_results("suricata", {}).get("alerts", []):
-            if re.findall(pattern, alert.get("signature", ""), re.I):
+            if alert.get("sid", 0) not in banned_sids and \
+               re.findall(pattern, alert.get("signature", ""), re.I):
                 return True
         return False
 


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
add support to provide banned sids when checking suricata
##### The goal of my change is:
add more power to suricata checking
##### What I have tested about my change is:
