### PR TITLE
def add_config may causes error with “Unable to import package modules.packages.None”

### DIFF
--- a/cuckoo/core/guest.py
+++ b/cuckoo/core/guest.py
@@ -403,7 +403,10 @@ class GuestManager(object):
             if isinstance(value, datetime.datetime):
                 config.append("%s = %s" % (key, value.strftime("%Y%m%dT%H:%M:%S")))
             else:
-                config.append("%s = %s" % (key, value))
+                if value == None:
+                    config.append("%s =" % key)
+                else:
+                    config.append("%s = %s" % (key, value))
 
         data = {
             "filepath": os.path.join(self.analyzer_path, "analysis.conf"),


### PR DESCRIPTION

If the “value” in the for statement is null, when it comes to “config.append("%s = %s" % (key, value))” statement, it inserts “None” which is string because of “%s”, not None which is python object.
Finally, it causes ERROR with “Unable to import package modules.packages.None” message.

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
I added an if statement.

##### The goal of my change is:
Cuckoo run choose_package function with out Error and choose .hwp file successfully.

##### What I have tested about my change is:
Input .hwp file through the web interface with my code and without my code.
For testing or reproduce the issue, input .hwp via web interface.

I soon add an issue with details.

