### PR TITLE
avoid SSL/TLS problem with recent vSphere 6.7 release

### DIFF
--- a/cuckoo/machinery/vsphere.py
+++ b/cuckoo/machinery/vsphere.py
@@ -96,8 +96,7 @@ class vSphere(Machinery):
 
         # Workaround for PEP-0476 issues in recent Python versions
         if self.options.vsphere.unverified_ssl:
-            sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-            sslContext.verify_mode = ssl.CERT_NONE
+            sslContext = ssl._create_unverified_context()
             self.connect_opts["sslContext"] = sslContext
             log.warn("Turning off SSL certificate verification!")
 


### PR DESCRIPTION
TLSv1 is unsupported in recent vSphere.
Using '_create_unverified_context' for create correct context.

This resolve #2318 