### PR TITLE
Correcting typo

### DIFF
--- a/docs/book/development/pycharm.rst
+++ b/docs/book/development/pycharm.rst
@@ -48,7 +48,7 @@ JavaScript transpiling
 .. CAUTION::
    Transpiling JavaScript through Pycharm file watchers is not recommended. The recommended way is explained in the 'Frontend' section of the documentation.
 
-The Javascript code in Cuckoo web is developed in ECMASript 6. For browser compatibility, this will need to be transpiled back to ECMAScript 5.
+The Javascript code in Cuckoo web is developed in ECMAScript 6. For browser compatibility, this will need to be transpiled back to ECMAScript 5.
 
 Firstly, make Pycharm regonize and understand the ECMAScript 6 syntax. Go to ``File->Settings->Languages & Frameworks->Javascript`` and pick 'ECMAScript 6' from the 'Javascript language version' dropdown. Hit ``Apply``.
 


### PR DESCRIPTION
Correcting "ECMASript 6" to "ECMAScript 6" line 51

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is: Correcting "ECMASript 6" to "ECMAScript 6" line 51

##### The goal of my change is: To correct a little typo in doc

##### What I have tested about my change is: 
