### PR TITLE
Missing attribute: errno

### DIFF
--- a/cuckoo/core/resultserver.py
+++ b/cuckoo/core/resultserver.py
@@ -54,7 +54,7 @@ class ResultServer(SocketServer.ThreadingTCPServer, object):
                 SocketServer.ThreadingTCPServer.__init__(
                     self, server_addr, ResultHandler, *args, **kwargs
                 )
-            except Exception as e:
+            except EnvironmentError as e:
                 if e.errno == errno.EADDRINUSE:
                     if config("cuckoo:resultserver:force_port"):
                         raise CuckooCriticalError(


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
`cuckoo.core.resultserver` handled vanilla `Exception`s which are not guaranteed to have the `errno` attribute.  `EnvironmentError` exceptions will have the `errno` attribute.  The only exception that `SocketServer` should throw is a `socket.error` which is a subclass of `IOError` which is a subclass of `EnvironmentError`.  So, changing the exception type of this try/except block is sufficient to solve this problem.

##### The goal of my change is:
Fix for #2270 

##### What I have tested about my change is:
Starting the resultserver with bogus parameters to force the exception.

##### I'd like input on:
Non-`EnvironmentError` exceptions currently are unhandled as they should not be generated by normal operation of `SocketServer.ThreadingTCPServer.__init__`.  We may want to consider adding a generic `except Exception as e` branch that raises a `CuckooCriticalError` in case the raised exception is not a subclass of `EnvironmentError`.