### PR TITLE
Debian 9 debugging symbol installation

### DIFF
--- a/docs/book/installation/guest/linux.rst
+++ b/docs/book/installation/guest/linux.rst
@@ -56,6 +56,10 @@ Install kernel debugging symbols::
 
     $ sudo apt-get update
     $ sudo apt-get install linux-image-$(uname -r)-dbgsym
+    
+(For Debian 9 amd64) Install kernel debugging symbols::
+
+    $ sudo apt-get install linux-image-$(uname -r)-dbg
 
 Patch SystemTap tapset (this will change in the future)::
 


### PR DESCRIPTION
Hello,

I've tried to install several times the linux image debugging symbols using the provided information from the documentation, (Line 45 to 58) without success.

So I used the available package on debian linux-image-$(uname -r)-dbg and it seems to work well.

It's easier for users if they don't have to add another repository and key (for example keyserver.ubuntu.com is down currently).

/!\ I don't know if using the standard image-dbg from the debina repo remove some analysis functionality /!\

Thanks for contributing! But first: did you read our community guidelines? Yes
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is: I added a line on how to install the package for debian 9

##### The goal of my change is: Have a functional example of debugging symbol installation for a Debian 9 linux guest

##### What I have tested about my change is: Installed a linux guest image (debian 9 amd64) and run several samples on it. (All worked)
