### PR TITLE
Bugfix : String extraction does not work on Windows host

### DIFF
--- a/cuckoo/processing/strings.py
+++ b/cuckoo/processing/strings.py
@@ -29,12 +29,14 @@ class Strings(Processing):
                 )
 
             try:
-                data = open(self.file_path, "r").read(self.MAX_FILESIZE)
+                data = open(self.file_path, "rb").read(self.MAX_FILESIZE)
             except (IOError, OSError) as e:
                 raise CuckooProcessingError("Error opening file %s" % e)
 
-            strings = re.findall("[\x1f-\x7e]{6,}", data)
-            for s in re.findall("(?:[\x1f-\x7e][\x00]){6,}", data):
+            strings = []
+            for s in re.findall(b"[\x1f-\x7e]{6,}", data):
+                strings.append(s.decode("utf-8"))
+            for s in re.findall(b"(?:[\x1f-\x7e][\x00]){6,}", data):
                 strings.append(s.decode("utf-16le"))
 
         # Now limit the amount & length of the strings.


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
cuckoo/processing/strings.py

##### The goal of my change is: 
Bugfix for Windows host : [https://github.com/cuckoosandbox/cuckoo/issues/2425](https://github.com/cuckoosandbox/cuckoo/issues/2425)

##### What I have tested about my change is:
String extraction of static analysis.
I tested it on both Windows guest and Linux guest.