### PR TITLE
Add missing .vbs extension if needed in vbs package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ If you want to contribute to development, report a bug, make a feature request
 or ask a question, please first take a look at our `community guidelines`_.
 For development, please also take a look at the `contribution requirements`_.
 Make sure you check our existing Issues and Pull Requests and that you join
-our `IRC or Slack channel <https://cuckoosandbox.org/discussion>`_.
+our IRC at `#cuckoosandbox` on FreeNode.
 
 For setup instructions, please refer
 `to <https://cuckoo.sh/docs/installation/host/requirements.html>`_

--- a/cuckoo/data/analyzer/windows/modules/packages/vbs.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/vbs.py
@@ -3,7 +3,12 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import os
+import logging
+
 from lib.common.abstracts import Package
+
+log = logging.getLogger(__name__)
 
 class VBS(Package):
     """VBS analysis package."""
@@ -13,4 +18,9 @@ class VBS(Package):
 
     def start(self, path):
         wscript = self.get_path("WScript")
+        if not path.endswith(".vbs"):
+            os.rename(path, path + ".vbs")
+            path += ".vbs"
+            log.info("Submitted file is missing extension, added .vbs")
+
         return self.execute(wscript, args=[path], trigger="file:%s" % path)


### PR DESCRIPTION
##### What I have added/changed is:

Automatically add .vbs extension in the VBS package if the files does not have it because wscript.exe requires the extension to be present.
