### PR TITLE
Intregated Floss into strings processing

### DIFF
--- a/cuckoo/common/abstracts.py
+++ b/cuckoo/common/abstracts.py
@@ -791,6 +791,7 @@ class Processing(object):
         self.shots_path = os.path.join(self.analysis_path, "shots")
         self.pcap_path = os.path.join(self.analysis_path, "dump.pcap")
         self.pmemory_path = os.path.join(self.analysis_path, "memory")
+        self.str_script_path = os.path.join(self.analysis_path, "str_script")
         self.memory_path = os.path.join(self.analysis_path, "memory.dmp")
         self.mitmout_path = os.path.join(self.analysis_path, "mitm.log")
         self.mitmerr_path = os.path.join(self.analysis_path, "mitm.err")

--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -563,7 +563,7 @@ class Config(object):
             },
             "procmemory": {
                 "enabled": Boolean(True),
-                "idapro": Boolean(False),
+                "idapro_dmp_sct": Boolean(False),
                 "extract_img": Boolean(True),
                 "extract_dll": Boolean(False),
                 "dump_delete": Boolean(False),
@@ -592,6 +592,13 @@ class Config(object):
             },
             "strings": {
                 "enabled": Boolean(True),
+                "floss": Boolean(True),
+                "min_str_len": Int(4),
+                "max_str_len": Int(1024),
+                "max_str_cnt": Int(2048),
+                "idapro_str_sct": Boolean(False),
+                "radare_str_sct": Boolean(False),
+                "x64dbg_str_sct": Boolean(False),
             },
             "suricata": {
                 "enabled": Boolean(False),

--- a/cuckoo/core/resultserver.py
+++ b/cuckoo/core/resultserver.py
@@ -310,7 +310,7 @@ class ResultHandler(SocketServer.BaseRequestHandler):
         self.rawlogfd.write(self.startbuf)
 
     def create_folders(self):
-        folders = "shots", "files", "logs", "buffer", "extracted"
+        folders = "shots", "files", "logs", "buffer", "extracted", "str_script"
 
         try:
             Folders.create(self.storagepath, folders)

--- a/cuckoo/private/cwd/conf/processing.conf
+++ b/cuckoo/private/cwd/conf/processing.conf
@@ -77,7 +77,7 @@ enabled = {{ processing.procmemory.enabled }}
 # generation of IDA Python-based script files. Although currently symbols and
 # such are not properly recovered, it is still nice to get a quick look at
 # specific memory addresses of a process.
-idapro = {{ processing.procmemory.idapro }}
+idapro_dmp_sct = {{ processing.procmemory.idapro_dmp_sct }}
 # Extract executable images from this process memory dump. This allows us to
 # relatively easily extract injected executables.
 extract_img = {{ processing.procmemory.extract_img }}
@@ -117,7 +117,30 @@ enabled = {{ processing.static.enabled }}
 pdf_timeout = {{ processing.static.pdf_timeout }}
 
 [strings]
+# Enable searching for readable strings in binary files.
 enabled = {{ processing.strings.enabled }}
+# Enable automatic string decoding with floss. Floss will attempt to decode
+# encoded strings in a Windows PE file by analyzing and stepping through what 
+# it guesses to be decoding functions. Floss will also recover any stackstrings,
+# or strings that are formed by pushing individual characters onto the stack,
+# if any are present in the binary. Enabling floss will add 5 - 15 seconds to 
+# runtime.
+floss = {{ processing.strings.floss }}
+# Minimum length of strings to print
+min_str_len = {{ processing.strings.min_str_len }}
+# Maximum length of found strings. Strings beyond this length will be printed
+# as truncated strings.
+max_str_len = {{ processing.strings.max_str_len }}
+# Maximum total number of static strings to show. If more than this amount of
+# static strings are found, '[snip]' will be printed as the last string.
+max_str_cnt = {{ processing.strings.max_str_cnt }}
+# Generate an Ida Pro annotated script with decoded strings floss found
+# in idb database, if any.
+idapro_str_sct = {{ processing.strings.idapro_str_sct }}
+# Generate a Radare script to annotate decoded strings in Radare, if found.
+radare_str_sct = {{ processing.strings.radare_str_sct }}
+# Generate a x64dbg database/json file to annotate decoded strings, if found.
+x64dbg_str_sct = {{ processing.strings.x64dbg_str_sct }}
 
 [suricata]
 enabled = {{ processing.suricata.enabled }}

--- a/cuckoo/private/cwd/conf/processing.conf
+++ b/cuckoo/private/cwd/conf/processing.conf
@@ -123,10 +123,11 @@ enabled = {{ processing.strings.enabled }}
 # encoded strings in a Windows PE file by analyzing and stepping through what 
 # it guesses to be decoding functions. Floss will also recover any stackstrings,
 # or strings that are formed by pushing individual characters onto the stack,
-# if any are present in the binary. Enabling floss will add 5 - 15 seconds to 
+# if any are present in the binary. Enabling Floss may add anywhere from 15
+# seconds to a few minutes to the overall processing time.
 # runtime.
 floss = {{ processing.strings.floss }}
-# Minimum length of strings to print
+# Minimum length of strings to print.
 min_str_len = {{ processing.strings.min_str_len }}
 # Maximum length of found strings. Strings beyond this length will be printed
 # as truncated strings.
@@ -134,12 +135,12 @@ max_str_len = {{ processing.strings.max_str_len }}
 # Maximum total number of static strings to show. If more than this amount of
 # static strings are found, '[snip]' will be printed as the last string.
 max_str_cnt = {{ processing.strings.max_str_cnt }}
-# Generate an Ida Pro annotated script with decoded strings floss found
-# in idb database, if any.
+# Generate an Ida Pro annotated script with decoded strings floss found, if any.
 idapro_str_sct = {{ processing.strings.idapro_str_sct }}
-# Generate a Radare script to annotate decoded strings in Radare, if found.
+# Generate a Radare script to annotate decoded strings Floss found, if any.
 radare_str_sct = {{ processing.strings.radare_str_sct }}
-# Generate a x64dbg database/json file to annotate decoded strings, if found.
+# Generate a x64dbg database/json file to annotate decoded strings Floss found,
+# if any.
 x64dbg_str_sct = {{ processing.strings.x64dbg_str_sct }}
 
 [suricata]

--- a/cuckoo/processing/procmemory.py
+++ b/cuckoo/processing/procmemory.py
@@ -170,7 +170,7 @@ class ProcessMemory(Processing):
 
                 ExtractManager.for_task(self.task["id"]).peek_procmem(proc)
 
-                if self.options.get("idapro"):
+                if self.options.get("idapro_dmp_sct"):
                     self.create_idapy(proc)
 
                 if self.options.get("extract_img"):

--- a/cuckoo/processing/strings.py
+++ b/cuckoo/processing/strings.py
@@ -5,22 +5,32 @@
 
 import os.path
 import re
+import floss
+import vivisect
 
 from cuckoo.common.abstracts import Processing
 from cuckoo.common.exceptions import CuckooProcessingError
 
 class Strings(Processing):
-    """Extract strings from analyzed file."""
+    """Extract encoded & static strings from analyzed file with floss."""
     MAX_FILESIZE = 16*1024*1024
     MAX_STRINGCNT = 2048
     MAX_STRINGLEN = 1024
+    MIN_STRINGLEN = 4
 
     def run(self):
-        """Run extract of printable strings.
-        @return: list of printable strings.
+        """Run floss on analyzed file.
+        @return: floss results dict.
         """
         self.key = "strings"
-        strings = []
+        recovered_strings = {}
+
+        STRING_TYPES = [
+            "acsii",
+            "utf16",
+            "decoded",
+            "stack"
+        ]
 
         if self.task["category"] == "file":
             if not os.path.exists(self.file_path):
@@ -33,13 +43,48 @@ class Strings(Processing):
             except (IOError, OSError) as e:
                 raise CuckooProcessingError("Error opening file %s" % e)
 
-            strings = re.findall("[\x1f-\x7e]{6,}", data)
-            for s in re.findall("(?:[\x1f-\x7e][\x00]){6,}", data):
-                strings.append(s.decode("utf-16le"))
+            # Extract static strings
+            acsii_strings = floss.strings.extract_ascii_strings(
+                data,
+                self.MIN_STRINGLEN
+            )
+            uft16_strings = floss.strings.extract_unicode_strings(
+                data,
+                self.MIN_STRINGLEN
+            )
+
+            # Prepare FLOSS for extracting hidden & encoded strings
+            vw = vivisect.VivWorkspace()
+            vw.loadFromFile(self.file_path)
+            vw.analyze()
+
+            selected_functions = floss.main.select_functions(vw, None)
+            decoding_functions_candidates = floss.identification_manager.identify_decoding_functions(
+                vw,
+                floss.main.get_all_plugins(),
+                selected_functions
+            )
+
+            # Decode & extract hidden & encoded strings
+            decoded_strings = floss.main.decode_strings(
+                vw,
+                decoding_functions_candidates,
+                self.MIN_STRINGLEN
+            )
+            stack_strings = floss.stackstrings.extract_stackstrings(
+                vw,
+                selected_functions,
+                self.MIN_STRINGLEN
+            )
 
         # Now limit the amount & length of the strings.
-        strings = strings[:self.MAX_STRINGCNT]
-        for idx, s in enumerate(strings):
-            strings[idx] = s[:self.MAX_STRINGLEN]
+        results = [acsii_strings, uft16_strings, decoded_strings, stack_strings]
+        for strings in results:
+            strings = strings[:self.MAX_STRINGCNT]
+            for idx, s in enumerate(strings):
+                strings[idx] = s[:self.MAX_STRINGLEN]
 
-        return strings
+        for i in len(STRING_TYPES):
+            recovered_strings[STRING_TYPES[i]] = results[i]
+
+        return recovered_strings

--- a/cuckoo/processing/strings.py
+++ b/cuckoo/processing/strings.py
@@ -28,9 +28,6 @@ class Strings(Processing):
         self.MIN_STRINGLEN = int(self.options.get("min_str_len"))
         self.MAX_STRINGLEN = self.options.get("max_str_len")
         self.MAX_STRINGCNT = self.options.get("max_str_cnt")
-        self.idapro = self.options.get("idapro_str_sct")
-        self.radare = self.options.get("radare_str_sct")
-        self.x64dbg = self.options.get("x64dbg_str_sct")
         self.MAX_FILESIZE = 16*1024*1024
         
         STRING_TYPES = [
@@ -106,23 +103,32 @@ class Strings(Processing):
 
                 if len(decoded_strings) or len(stack_strings):
                     # Create annotated scripts
-                    if self.idapro:
+                    if self.options.get("idapro_str_sct"):
+                        idapro_sct_name = base_name + ".idb"
+                        strings["idapro_sct_name"] = idapro_sct_name
+
                         main.create_ida_script(
-                            self.file_path, os.path.join(self.str_script_path, base_name + ".idb"),
-                            decoded_strings, stack_strings, True
+                            self.file_path, os.path.join(self.str_script_path, idapro_sct_name), 
+                            decoded_strings, stack_strings
                         )
 
-                    if self.radare:
+                    if self.options.get("radare_str_sct"):
+                        radare_sct_name = base_name + ".r2"
+                        strings["radare_sct_name"] = radare_sct_name
+
                         main.create_r2_script(
-                            self.file_path, os.path.join(self.str_script_path, base_name + ".r2"),
-                            decoded_strings, stack_strings, True
+                            self.file_path, os.path.join(self.str_script_path, radare_sct_name), 
+                            decoded_strings, stack_strings
                         )
 
-                    if self.x64dbg:
+                    if self.options.get("x64dbg_str_sct"):
+                        x64dbg_sct_name = base_name + ".json"
+                        strings["x64dbg_sct_name"] = x64dbg_sct_name
+
                         imagebase = vw.filemeta.values()[0]['imagebase']
                         main.create_x64dbg_database(
-                            self.file_path, os.path.join(self.str_script_path, base_name + ".json"),
-                            imagebase, decoded_strings, True
+                            self.file_path, os.path.join(self.str_script_path, base_name + ".json"), 
+                            imagebase, decoded_strings
                         )
 
                 # convert Floss strings into regular, readable strings

--- a/cuckoo/processing/strings.py
+++ b/cuckoo/processing/strings.py
@@ -3,13 +3,12 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-import floss
 import os.path
-import re
 import vivisect
 
 from cuckoo.common.abstracts import Processing
 from cuckoo.common.exceptions import CuckooProcessingError
+from cuckoo.common.objects import File
 from floss import identification_manager as id_man
 from floss import main
 from floss import stackstrings
@@ -42,45 +41,68 @@ class Strings(Processing):
                 )
 
             try:
+                f = File(self.file_path)
+                filename = os.path.basename(self.task["target"])
+                ext = filename.split(os.path.extsep)[-1].lower()
                 data = open(self.file_path, "r").read(self.MAX_FILESIZE)
             except (IOError, OSError) as e:
                 raise CuckooProcessingError("Error opening file %s" % e)
 
-            # Prepare FLOSS for extracting hidden & encoded strings
-            vw = vivisect.VivWorkspace()
-            vw.loadFromFile(self.file_path)
-            vw.analyze()
-
-            selected_functions = main.select_functions(vw, None)
-            decoding_functions_candidates = id_man.identify_decoding_functions(
-                vw, main.get_all_plugins(), selected_functions
-            )
-
-            # Decode & extract hidden & encoded strings
-            decoded_strings = main.decode_strings(
-                vw, decoding_functions_candidates, self.MIN_STRINGLEN
-            )
-            for i, str in enumerate(decoded_strings):
-                decoded_strings[i] = main.sanitize_string_for_printing(str.s)
-
-            stack_strings = []
-            stack_strs = stackstrings.extract_stackstrings(
-                vw, selected_functions, self.MIN_STRINGLEN
-            )
-            for str in stack_strs:
-                stack_strings.append(str.s)
-
             # Extract static strings
             static_strings = []
             for str in static.extract_ascii_strings(data, self.MIN_STRINGLEN):
-                static_strings.append(str.s)
+                static_strings.append(str.s[:self.MAX_STRINGLEN])
 
             for str in static.extract_unicode_strings(data, self.MIN_STRINGLEN):
-                static_strings.append(str.s)
+                static_strings.append(str.s[:self.MAX_STRINGLEN])
 
-            results = [decoded_strings, stack_strings, static_strings]
+            if len(static_strings) > self.MAX_STRINGCNT:
+                static_strings = static_strings[:self.MAX_STRINGCNT]
+                static_strings.append("[snip]")
 
-            for i, str_type in enumerate(STRING_TYPES):
-                strings[str_type] = results[i]
+            package = self.task.get("package")
+
+            if package == "exe" or ext == "exe" or "PE32" in f.get_type():
+                try:
+                    # Prepare FLOSS for extracting hidden & encoded strings
+                    vw = vivisect.VivWorkspace()
+                    vw.loadFromFile(self.file_path)
+                    vw.analyze()
+
+                    selected_functions = main.select_functions(vw, None)
+                    decoding_functions_candidates = id_man.identify_decoding_functions(
+                        vw, main.get_all_plugins(), selected_functions
+                    )
+                except Exception as e:
+                    raise CuckooProcessingError("Error analyzing file with vivisect: %s" % e)
+
+                try:
+                    # Decode & extract hidden & encoded strings
+                    decoded_strings = main.decode_strings(
+                        vw, decoding_functions_candidates, self.MIN_STRINGLEN
+                    )
+
+                    stack_strs = stackstrings.extract_stackstrings(
+                        vw, selected_functions, self.MIN_STRINGLEN
+                    )
+                except Exception as e:
+                    raise CuckooProcessingError("Error extracting strings with floss: %s" % e)
+
+                for i, str in enumerate(decoded_strings):
+                    decoded_strings[i] = main.sanitize_string_for_printing(str.s)
+                    
+                uniq_decoded_strings = [x for x in decoded_strings if not x in static_strings]
+
+                stack_strings = []
+                for str in stack_strs:
+                    stack_strings.append(str.s)
+
+                results = [uniq_decoded_strings, stack_strings, static_strings]
+
+                for i, str_type in enumerate(STRING_TYPES):
+                    strings[str_type] = results[i]
+
+            else:
+                strings["static"] = static_strings
 
         return strings

--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -141,6 +141,33 @@ class MongoDB(Report):
                     if f.valid():
                         extracted["extracted_id"] = self.store_file(f)
 
+        # Store the scripts that Floss generated in GredFS and reference
+        # them back in the report.
+        if "strings" in report:
+            if "idapro_sct_name" in report["strings"]:
+                idapro_sct_path = os.path.join(
+                    self.analysis_path, "str_script", report["strings"]["idapro_sct_name"]
+                )
+                idapro_sct_file = File(idapro_sct_path)
+                if idapro_sct_file.valid():
+                    report["strings"]["idapro_sct_id"] = self.store_file(idapro_sct_file)
+
+            if "radare_sct_name" in report["strings"]:
+                radare_sct_path = os.path.join(
+                    self.analysis_path, "str_script", report["strings"]["radare_sct_name"]
+                )
+                radare_sct_file = File(radare_sct_path)
+                if radare_sct_file.valid():
+                    report["strings"]["radare_sct_id"] = self.store_file(radare_sct_file)
+
+            if "x64dbg_sct_name" in report["strings"]:
+                x64dbg_sct_path = os.path.join(
+                    self.analysis_path, "str_script", report["strings"]["x64dbg_sct_name"]
+                )
+                x64dbg_sct_file = File(x64dbg_sct_path)
+                if x64dbg_sct_file.valid():
+                    report["strings"]["x64dbg_sct_id"] = self.store_file(x64dbg_sct_file)
+
         # Walk through the dropped files, store them in GridFS and update the
         # report with the ObjectIds.
         new_dropped = []

--- a/cuckoo/web/templates/analysis/pages/static/_strings.html
+++ b/cuckoo/web/templates/analysis/pages/static/_strings.html
@@ -1,6 +1,24 @@
 <section id="static_strings">
+    {% if report.analysis.strings.idapro_sct_name %}
+        <div class="header-right valign-bottom">
+            <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.idapro_sct_id %}" title="Download Ida Pro Script">Download Ida Pro Script</a>
+        </div>
+    {% endif %}
+
+    {% if report.analysis.strings.radare_sct_name %}
+        <div class="header-right valign-bottom">
+            <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.radare_sct_id %}" title="Download Radare2 Script">Download Radare2 Script</a>
+        </div>
+    {% endif %}
+
+    {% if report.analysis.strings.x64dbg_sct_name %}
+        <div class="header-right valign-bottom">
+            <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.x64dbg_sct_id %}" title="Download x64dbg Database">Download x64dbg Database</a>
+        </div>
+    {% endif %}
+    
     {% if report.analysis.strings.decoded %}
-    <h4>Decoded Strings</h4>
+        <h4>Decoded Strings</h4>
         <div class="well" style="font-family:monospace;width:75%;">
             {% for string in report.analysis.strings.decoded %}
                 <div>{{string}}</div>

--- a/cuckoo/web/templates/analysis/pages/static/_strings.html
+++ b/cuckoo/web/templates/analysis/pages/static/_strings.html
@@ -1,7 +1,32 @@
 <section id="static_strings">
-    <div class="well" style="font-family:monospace;width:75%;">
-        {% for string in report.analysis.strings %}
-            <div>{{string}}</div>
-        {% endfor %}
-    </div>
+    {% if report.analysis.strings.decoded %}
+        <div class="well" style="font-family:monospace;width:75%;">
+            <h4>Decoded Strings</h4>
+            {% for string in report.analysis.strings.decoded %}
+                <div>{{string}}</div>
+            {% endfor %}
+        </div>
+    {% endif &}
+
+    <br>
+
+    {% if report.analysis.strings.stack %}
+        <div class="well" style="font-family:monospace;width:75%;">
+            <h4>Stackstrings</h4>
+            {% for string in report.analysis.strings.stack %}
+                <div>{{string}}</div>
+            {% endfor %}
+        </div>
+    {% endif &}
+
+    <br>
+
+    {% if report.analysis.strings.static %}
+        <div class="well" style="font-family:monospace;width:75%;">
+            <h4>Static Strings</h4>
+            {% for string in report.analysis.strings.static %}
+                <div>{{string}}</div>
+            {% endfor %}
+        </div>
+    {% endif &}
 </section>

--- a/cuckoo/web/templates/analysis/pages/static/_strings.html
+++ b/cuckoo/web/templates/analysis/pages/static/_strings.html
@@ -1,18 +1,18 @@
 <section id="static_strings">
     {% if report.analysis.strings.idapro_sct_name %}
-        <div class="header-right valign-bottom">
+        <div>
             <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.idapro_sct_id %}" title="Download Ida Pro Script">Download Ida Pro Script</a>
         </div>
     {% endif %}
 
     {% if report.analysis.strings.radare_sct_name %}
-        <div class="header-right valign-bottom">
+    <div>
             <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.radare_sct_id %}" title="Download Radare2 Script">Download Radare2 Script</a>
         </div>
     {% endif %}
 
     {% if report.analysis.strings.x64dbg_sct_name %}
-        <div class="header-right valign-bottom">
+    <div>
             <a href="{% url "analysis.views.file" "str_script" report.analysis.strings.x64dbg_sct_id %}" title="Download x64dbg Database">Download x64dbg Database</a>
         </div>
     {% endif %}

--- a/cuckoo/web/templates/analysis/pages/static/_strings.html
+++ b/cuckoo/web/templates/analysis/pages/static/_strings.html
@@ -1,32 +1,28 @@
 <section id="static_strings">
     {% if report.analysis.strings.decoded %}
+    <h4>Decoded Strings</h4>
         <div class="well" style="font-family:monospace;width:75%;">
-            <h4>Decoded Strings</h4>
             {% for string in report.analysis.strings.decoded %}
                 <div>{{string}}</div>
             {% endfor %}
         </div>
-    {% endif &}
-
-    <br>
+    {% endif %}
 
     {% if report.analysis.strings.stack %}
+        <h4>Stackstrings</h4>    
         <div class="well" style="font-family:monospace;width:75%;">
-            <h4>Stackstrings</h4>
             {% for string in report.analysis.strings.stack %}
                 <div>{{string}}</div>
             {% endfor %}
         </div>
-    {% endif &}
-
-    <br>
+    {% endif %}
 
     {% if report.analysis.strings.static %}
+        <h4>Static Strings</h4>
         <div class="well" style="font-family:monospace;width:75%;">
-            <h4>Static Strings</h4>
             {% for string in report.analysis.strings.static %}
                 <div>{{string}}</div>
             {% endfor %}
         </div>
-    {% endif &}
+    {% endif %}
 </section>


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Refactored the Strings processing module to use [Floss](https://github.com/fireeye/flare-floss) to attempt to grab encoded strings in the binary as well as static strings. I have also added a few options, such as allowing the user to choose not to use Floss when analyzing the strings in the target binary, whether to generate Ida Pro, Radare2, or x64dbg scripts to annotate the workspace with the decoded strings, and more.

##### The goal of my change is:
Allow Cuckoo to gleam even more useful information from PE32 binaries with Floss.

##### What I have tested about my change is:
Analyzed multiple PE32 binaries with Cuckoo, verified that the strings module works as expected and that decoded strings found by Floss are correctly printed in the web report.
