### PR TITLE
Allow specifying list of IRMA probes to use

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -635,6 +635,7 @@ class Config(object):
                 "scan": Boolean(False),
                 "force": Boolean(False),
                 "url": String(),
+                "probes": String(),
             },
         },
         "qemu": {

--- a/cuckoo/private/cwd/conf/processing.conf
+++ b/cuckoo/private/cwd/conf/processing.conf
@@ -171,3 +171,8 @@ force = {{ processing.irma.force }}
 # URL to your IRMA installation
 # For example : https://your.irma.host
 url = {{ processing.irma.url }}
+# Probes to use on your IRMA instance
+# If not specified, will default to using all available probes
+# Expects comma separated list
+# For example : ClamAV,F-Secure,Avast,ESET,eScan,Avira,Sophos,McAfee,Kaspersky,GData,Comodo,Bitdefender
+probes = {{ processing.irma.probes }}

--- a/cuckoo/processing/irma.py
+++ b/cuckoo/processing/irma.py
@@ -60,6 +60,8 @@ class Irma(Processing):
         params = {
             "force": force,
         }
+        if self.options.get("probes"):
+            params["probes"] = self.options.get("probes")
         url = urlparse.urljoin(
             self.url, "/api/v1.1/scans/%s/launch" % init.get("id")
         )


### PR DESCRIPTION
##### What I have added/changed is:
Add a new optional config setting for specifying a list of probes to the IRMA processing module.

##### The goal of my change is:
This introduces the possibility of specifying which probes to use in IRMA when submitting from Cuckoo i.e. for example exclude VirusTotal when it's already being done by Cuckoo itself 

##### What I have tested about my change is:
- That the probe list is respected and used.
- If no probes option is specified Cuckoo will default to using all available probes
- That nothing breaks with result retrieval or anywhere else