### PR TITLE
Add configuration option to kvm.conf for custom dsn option use.

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -391,6 +391,7 @@ class Config(object):
         },
         "kvm": {
             "kvm": {
+                "dsn": String("qemu:///system", required=False),
                 "interface": String("virbr0"),
                 "machines": List(String, "cuckoo1"),
             },

--- a/cuckoo/compat/config.py
+++ b/cuckoo/compat/config.py
@@ -717,6 +717,7 @@ def _206_210(c):
     # upgrading users. TODO Might need to revisited once we write back config.
     c["cuckoo"]["cuckoo"]["api_token"] = None
     c["cuckoo"]["cuckoo"]["web_secret"] = None
+    c["kvm"]["kvm"]["dsn"] = "qemu:///system"
     c["processing"]["irma"]["probes"] = None
     return c
 

--- a/cuckoo/machinery/kvm.py
+++ b/cuckoo/machinery/kvm.py
@@ -2,11 +2,35 @@
 # Copyright (C) 2014-2016 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
-
 from cuckoo.common.abstracts import LibVirtMachinery
+from cuckoo.common.exceptions import CuckooCriticalError
+from cuckoo.common.exceptions import CuckooMachineError
+
+try:
+    import libvirt
+    HAVE_LIBVIRT = True
+except ImportError:
+    HAVE_LIBVIRT = False
+
 
 class KVM(LibVirtMachinery):
-    """Virtualization layer for KVM based on python-libvirt."""
+    """KVM virtualization layer based on python-libvirt."""
 
-    # Set KVM connection string.
-    dsn = "qemu:///system"
+    def _initialize_check(self):
+        """Init KVM configuration to open libvirt dsn connection."""
+        self._sessions = {}
+        if not self.options.kvm.dsn:
+            raise CuckooMachineError("KVM(i) DSN is missing, please add it to the config file")
+        self.dsn = self.options.kvm.dsn
+        super(KVM, self)._initialize_check()
+
+    def _connect(self):
+        """Return global connection."""
+        try:
+            return libvirt.open(self.dsn)
+        except libvirt.libvirtError as libvex:
+            raise CuckooCriticalError("libvirt returned an exception on connection: %s" % libvex)
+
+    def _disconnect(self, conn):
+        """Disconnect, ignore request to disconnect."""
+        pass

--- a/cuckoo/private/cwd/conf/kvm.conf
+++ b/cuckoo/private/cwd/conf/kvm.conf
@@ -1,4 +1,7 @@
 [kvm]
+# Specify a libvirt URI connection string
+dsn = {{ kvm.kvm.dsn }}
+
 # Specify a comma-separated list of available machines to be used. For each
 # specified ID you have to define a dedicated section containing the details
 # on the respective machine. (E.g. cuckoo1,cuckoo2,cuckoo3)

--- a/docs/book/customization/machinery.rst
+++ b/docs/book/customization/machinery.rst
@@ -106,6 +106,13 @@ this base class and specify your connection string, as in the example below:
         # Set connection string.
         dsn = "my:///connection"
 
+
+Starting with Cuckoo 2.0.7a1 you can use a custom dsn by setting it in the kvm.conf file.
+Example:
+
+    dsn = qemu+ssh://192.168.56.1/system
+
+
 This works for all the virtualization technologies supported by LibVirt. Just
 remember to check if your LibVirt package (if you are using one, for example
 from your Linux distribution) is compiled with the support for the technology

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1173,6 +1173,11 @@ def test_migration_206_210():
     Files.create(cwd("conf"), "auxiliary.conf", """
 [replay]
     """)
+    Files.create(cwd("conf"), "kvm.conf", """
+[kvm]
+machines = cuckoo1
+interface = virbr0
+    """)
     cfg = Config.from_confdir(cwd("conf"), loose=True)
     cfg = migrate(cfg, "2.0.6", "2.1.0")
 
@@ -1180,6 +1185,8 @@ def test_migration_206_210():
     assert cfg["cuckoo"]["cuckoo"]["api_token"] is None
     assert cfg["cuckoo"]["cuckoo"]["web_secret"] is None
     assert cfg["processing"]["irma"]["probes"] is None
+    assert cfg["kvm"]["kvm"]["dsn"] == "qemu:///system"
+
 
 class FullMigration(object):
     DIRPATH = None


### PR DESCRIPTION
What I have added/changed is:
Add config option for kvm machinery option in kvm.conf

The goal of my change is:
Make it easier to override the kvm dsn option instead of having to override the entire python file.

What I have tested about my change is:
I have tested my changes with tcp and ssh type of connection strings set with the dsn option in kvm.conf.