### PR TITLE
initial pass at adding option to retrieve full memory dump

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -336,6 +336,7 @@ def tasks_report(task_id, report_format="json"):
 
     bz_formats = {
         "all": {"type": "-", "files": ["memory.dmp"]},
+        "all_memory": {"type": "-", "files": []},
         "dropped": {"type": "+", "files": ["files"]},
         "package_files": {"type": "+", "files": ["package_files"]},
     }

--- a/docs/book/usage/api.rst
+++ b/docs/book/usage/api.rst
@@ -673,7 +673,11 @@ Returns the report associated with the specified task ID.
 **Parameters**:
 
 * ``id`` *(required)* *(int)* - ID of the task to get the report for
-* ``format`` *(optional)* - format of the report to retrieve [json/html/all/dropped/package_files]. If none is specified the JSON report will be returned. ``all`` returns all the result files as tar.bz2, ``dropped`` the dropped files as tar.bz2, ``package_files`` files uploaded to host by analysis packages.
+* ``format`` *(optional)* - format of the report to retrieve [json/html/all/all_memory/dropped/package_files]. If none is specified the JSON report will be returned.
+    * ``all`` returns all the result files as tar.bz2
+    * ``all_memory`` returns all the result files as tar.bz2, including the full memory dump if it was requested in the submission
+    * ``dropped`` the dropped files as tar.bz2
+    * ``package_files`` files uploaded to host by analysis packages.
 
 **Status codes**:
 


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

Added 'all_memory' option to /tasks/report API to include the memory.dmp file (if it's there) along with the associated addition in the documentation

##### The goal of my change is:

Be able to pull out the memory.dmp using the REST API

##### What I have tested about my change is:

Tested and it works as expected. GET /tasks/report/1/all_memory returns a .tar.bz2 file containing the memory.dmp file. 