### PR TITLE
Remove false positive PEiD Armadillo signatures from peutils UserDB

### DIFF
--- a/cuckoo/private/peutils/UserDB.TXT
+++ b/cuckoo/private/peutils/UserDB.TXT
@@ -813,10 +813,6 @@ ep_only = true
 signature = 55 8B EC 6A FF 68 98 71 40 00 68 48 2D 40 00 64 A1 00 00 00 00 50 64 89 25 00 00 00 00 83 EC 58
 ep_only = true
 
-[Armadillo v1.71]
-signature = 55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1
-ep_only = true
-
 [Armadillo v1.72 - v1.73]
 signature = 55 8B EC 6A FF 68 E8 C1 ?? ?? 68 F4 86 ?? ?? 64 A1 ?? ?? ?? ?? 50 64 89 25 ?? ?? ?? ?? 83 EC 58
 ep_only = true

--- a/cuckoo/private/peutils/UserDB.TXT
+++ b/cuckoo/private/peutils/UserDB.TXT
@@ -869,9 +869,10 @@ ep_only = true
 signature = 55 8B EC 6A FF 68 98 ?? ?? ?? 68 10 ?? ?? ?? 64 A1 ?? ?? ?? ?? 50 64 89 25 ?? ?? ?? ?? 83 EC 58 53 56 57 89 65 E8 FF 15
 ep_only = true
 
-[Armadillo v1.xx - v2.xx]
-signature = 55 8B EC 53 8B 5D 08 56 8B 75 0C 57 8B 7D 10 85 F6
-ep_only = true
+; False positive - https://www.zscaler.com/blogs/research/your-windows-8-packed
+;[Armadillo v1.xx - v2.xx]
+;signature = 55 8B EC 53 8B 5D 08 56 8B 75 0C 57 8B 7D 10 85 F6
+;ep_only = true
 
 [Armadillo v2.00]
 signature = 55 8B EC 6A FF 68 00 02 41 00 68 C4 A0 40 00 64 A1 00 00 00 00 50 64 89 25 00 00 00 00 83 EC 58


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Removed the PEiD Armadillo v1.71 signature from peutils signature db

##### The goal of my change is:
The PEiD Armadillo v1.71 signature is incorrect, the sequence matches on any binaries compiled with certain versions of MSVC, causing false positive packer detections.

Ref https://github.com/brad-accuvant/cuckoo-modified/commit/defb7b42120583c0d56efa68698ec3a625e106bf

##### What I have tested about my change is:
None