### PR TITLE
Fix CI error: Restrict weasyprint version as same as setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
         sudo mysql cuckootestimport < tests/files/sql/11my.sql
         psql -U postgres -c "CREATE DATABASE cuckootestimport"
         psql -U postgres cuckootestimport <tests/files/sql/11pg.sql >/dev/null
-        pip install psycopg2 mysql-python m2crypto==0.24.0 weasyprint
+        pip install psycopg2 mysql-python m2crypto==0.24.0 weasyprint==0.36
     else
         brew update || brew update
         brew install libmagic cairo pango mongodb


### PR DESCRIPTION
##### What I have added/changed is:

new version weasyprint is not support Python 2.7 anymore, which cause CI error

##### The goal of my change is:

Fix CI setup error

##### What I have tested about my change is:

https://travis-ci.org/jcppkkk/cuckoo/jobs/480289690