### PR TITLE
Delete Ubuntu libvirt's default REJECT rules

### DIFF
--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -148,6 +148,12 @@ def dns_forward(action, vm_ip, dns_ip, dns_port="53"):
 def forward_enable(src, dst, ipaddr):
     """Enable forwarding a specific IP address from one interface into
     another."""
+    # Delete libvirt's default FORWARD REJECT rules. e.g.:
+    # -A FORWARD -o virbr0 -j REJECT --reject-with icmp-port-unreachable
+    # -A FORWARD -i virbr0 -j REJECT --reject-with icmp-port-unreachable
+    run(settings.iptables, "-D", "FORWARD", "-i", src, "-j", "REJECT")
+    run(settings.iptables, "-D", "FORWARD", "-o", src, "-j", "REJECT")
+
     run(
         s.iptables, "-A", "FORWARD", "-i", src, "-o", dst,
         "--source", ipaddr, "-j", "ACCEPT"


### PR DESCRIPTION
The Ubuntu apt distribution of libvirt adds the following `iptables` rules when setting up a host-only interface. (visible by running `iptables -S`)

```
-A FORWARD -o virbr0 -j REJECT --reject-with icmp-port-unreachable
-A FORWARD -i virbr0 -j REJECT --reject-with icmp-port-unreachable
```

That prevents rooter's forwarding rules from working, since they are appended to the chain. These rules do not appear with the latest libvirt compiled from source. 

This commit has rooter delete the apt libvirt's default REJECT rules in iptables when `forward_enable()` is called. It has no effect on systems that do not have those rules,

Tested on:
Ubuntu 18.10 (GNU/Linux 4.18.0-13-generic x86_64)
libvirt 4.6.0 from apt repos
QEMU emulator version 2.12.0 (Debian 1:2.12+dfsg-3ubuntu8.2) from apt repos
