### PR TITLE
Add guidance for XP guests and mitmproxy

### DIFF
--- a/docs/book/installation/host/requirements.rst
+++ b/docs/book/installation/host/requirements.rst
@@ -51,6 +51,8 @@ install it within a separate ``virtualenv`` to isolate it and its requirements
 from Cuckoo's Python 2.7 environment. After installing mitmproxy in a separate
 virtualenv, include its binary path in the Cuckoo configuration, e.g.,
 ``/tmp/mitmproxy3/bin/mitmdump`` if the virtualenv is ``/tmp/mitmproxy3``.
+For XP guests, the mitm auxiliary requires that Windows Server 2003 Administration
+Tools Pack be installed.
 
 .. _Yara: https://github.com/plusvic/yara
 .. _Pydeep: https://github.com/kbandla/pydeep


### PR DESCRIPTION
When encountering the following error in analyzer log on XP guests:

```
[analyzer] ERROR: Cannot execute auxiliary module InstallCertificate: 2
Traceback (most recent call last):
  File "C:/tmp90hz4g/analyzer.py", line 622, in run
    aux.start()
  File "C:\tmp90hz4g\modules\auxiliary\installcert.py", line 38, in start
    stderr=subprocess.PIPE)
  File "C:\Python27\lib\subprocess.py", line 390, in __init__
    errread, errwrite)
  File "C:\Python27\lib\subprocess.py", line 640, in _execute_child
    startupinfo)
  File "C:\tmp90hz4g\lib\api\process.py", line 83, in spCreateProcessW
    raise WindowsError(KERNEL32.GetLastError())
WindowsError: 2
```

This means certutil.exe is not installed and needs to be installed from Windows Server 2003 Administration Tools Pack
https://www.microsoft.com/en-us/download/details.aspx?id=16770