### PR TITLE
VT query for dropped PE32/MS-DOS binaries ,not usefully functioning

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2012-2013 Claudio Guarnieri.
-# Copyright (C) 2014-2018 Cuckoo Foundation.
+# Copyright (C) 2014-2019 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -401,6 +401,28 @@ def tasks_report(task_id, report_format="json"):
                               " try again with JSON format")
         return open(report_path, "rb").read()
 
+@app.route("/tasks/summary/<int:task_id>")
+def tasks_summary(task_id):
+    report_path = cwd("reports", "report.json", analysis=task_id)
+    if not os.path.exists(report_path):
+        return json_error(404, "Report not found")
+
+    with open(report_path, "rb") as report_file:
+        report = json.load(report_file)
+
+    try:
+        del report["procmemory"]
+        del report["behavior"]["generic"]
+        del report["behavior"]["apistats"]
+        del report["behavior"]["processes"]
+        del report["debug"]
+        del report["screenshots"]
+        del report["metadata"]
+    except KeyError:
+        pass
+
+    return jsonify(report)
+
 @app.route("/tasks/screenshots/<int:task_id>")
 @app.route("/v1/tasks/screenshots/<int:task_id>")
 @app.route("/tasks/screenshots/<int:task_id>/<screenshot>")
@@ -473,7 +495,11 @@ def files_view(md5=None, sha256=None, sample_id=None):
     if not sample:
         return json_error(404, "File not found")
 
+    tasks = sorted(
+        list(map(lambda t: t.id, db.list_tasks(sample_id=sample.id)))
+    )
     response["sample"] = sample.to_dict()
+    response["sample"]["tasks"] = tasks
     return jsonify(response)
 
 @app.route("/files/get/<sha256>")

--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -148,6 +148,12 @@ def dns_forward(action, vm_ip, dns_ip, dns_port="53"):
 def forward_enable(src, dst, ipaddr):
     """Enable forwarding a specific IP address from one interface into
     another."""
+    # Delete libvirt's default FORWARD REJECT rules. e.g.:
+    # -A FORWARD -o virbr0 -j REJECT --reject-with icmp-port-unreachable
+    # -A FORWARD -i virbr0 -j REJECT --reject-with icmp-port-unreachable
+    run(s.iptables, "-D", "FORWARD", "-i", src, "-j", "REJECT")
+    run(s.iptables, "-D", "FORWARD", "-o", src, "-j", "REJECT")
+
     run(
         s.iptables, "-A", "FORWARD", "-i", src, "-o", dst,
         "--source", ipaddr, "-j", "ACCEPT"

--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -391,6 +391,7 @@ class Config(object):
         },
         "kvm": {
             "kvm": {
+                "dsn": String("qemu:///system", required=False),
                 "interface": String("virbr0"),
                 "machines": List(String, "cuckoo1"),
             },

--- a/cuckoo/common/whitelist.py
+++ b/cuckoo/common/whitelist.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 Cuckoo Foundation.
+# Copyright (C) 2015-2019 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -7,20 +7,33 @@ import os.path
 from cuckoo.misc import cwd
 
 domains = set()
+ips = set()
+
+def _load_whitelist(wlset, wl_file):
+    for b in (True, False):
+        private = {"private": True} if b else {}
+        wl_path = cwd("whitelist", wl_file, **private)
+        if not os.path.isfile(wl_path):
+            continue
+
+        with open(wl_path, "rb") as fp:
+            whitelist = fp.read()
+
+        for entry in whitelist.split("\n"):
+            entry = entry.strip()
+            if entry and not entry.startswith("#"):
+                wlset.add(entry)
 
 def is_whitelisted_domain(domain):
-    # Initialize the domain whitelist.
     if not domains:
-        for line in open(cwd("whitelist", "domain.txt", private=True), "rb"):
-            if not line.strip() or line.startswith("#"):
-                continue
-            domains.add(line.strip())
-
-        # Collect whitelist also from $CWD if available.
-        if os.path.exists(cwd("whitelist", "domain.txt")):
-            for line in open(cwd("whitelist", "domain.txt"), "rb"):
-                if not line.strip() or line.startswith("#"):
-                    continue
-                domains.add(line.strip())
+        # Initialize the domain whitelist.
+        _load_whitelist(domains, "domain.txt")
 
     return domain in domains
+
+def is_whitelisted_ip(ip):
+    if not ips:
+        # Initialize the ip whitelist.
+        _load_whitelist(ips, "ip.txt")
+
+    return ip in ips

--- a/cuckoo/compat/config.py
+++ b/cuckoo/compat/config.py
@@ -717,6 +717,7 @@ def _206_210(c):
     # upgrading users. TODO Might need to revisited once we write back config.
     c["cuckoo"]["cuckoo"]["api_token"] = None
     c["cuckoo"]["cuckoo"]["web_secret"] = None
+    c["kvm"]["kvm"]["dsn"] = "qemu:///system"
     c["processing"]["irma"]["probes"] = None
     return c
 

--- a/cuckoo/data/analyzer/windows/modules/packages/ps1.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/ps1.py
@@ -19,14 +19,15 @@ class PS1(Package):
 
     def start(self, path):
         powershell = self.get_path("PowerShell")
-        args = [
-            "-NoProfile", "-ExecutionPolicy", "unrestricted", "-File", path
-        ]
 
         # Enforce the .ps1 file extension as is required by powershell.
         if not path.endswith(".ps1"):
             os.rename(path, path + ".ps1")
             path += ".ps1"
             log.info("Submitted file is missing extension, added .ps1")
+
+        args = [
+            "-NoProfile", "-ExecutionPolicy", "unrestricted", "-File", path
+        ]
 
         return self.execute(powershell, args=args, trigger="file:%s" % path)

--- a/cuckoo/data/whitelist/ip.txt
+++ b/cuckoo/data/whitelist/ip.txt
@@ -1,0 +1,1 @@
+# You can add whitelisted IPs here.

--- a/cuckoo/machinery/kvm.py
+++ b/cuckoo/machinery/kvm.py
@@ -2,11 +2,35 @@
 # Copyright (C) 2014-2016 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
-
 from cuckoo.common.abstracts import LibVirtMachinery
+from cuckoo.common.exceptions import CuckooCriticalError
+from cuckoo.common.exceptions import CuckooMachineError
+
+try:
+    import libvirt
+    HAVE_LIBVIRT = True
+except ImportError:
+    HAVE_LIBVIRT = False
+
 
 class KVM(LibVirtMachinery):
-    """Virtualization layer for KVM based on python-libvirt."""
+    """KVM virtualization layer based on python-libvirt."""
 
-    # Set KVM connection string.
-    dsn = "qemu:///system"
+    def _initialize_check(self):
+        """Init KVM configuration to open libvirt dsn connection."""
+        self._sessions = {}
+        if not self.options.kvm.dsn:
+            raise CuckooMachineError("KVM(i) DSN is missing, please add it to the config file")
+        self.dsn = self.options.kvm.dsn
+        super(KVM, self)._initialize_check()
+
+    def _connect(self):
+        """Return global connection."""
+        try:
+            return libvirt.open(self.dsn)
+        except libvirt.libvirtError as libvex:
+            raise CuckooCriticalError("libvirt returned an exception on connection: %s" % libvex)
+
+    def _disconnect(self, conn):
+        """Disconnect, ignore request to disconnect."""
+        pass

--- a/cuckoo/machinery/virtualbox.py
+++ b/cuckoo/machinery/virtualbox.py
@@ -357,8 +357,8 @@ class VirtualBox(Machinery):
                 "VBoxManage failed to return its version: %s" % e
             )
 
-        # VirtualBox version 4 and 5.
-        if output.startswith("5"):
+        # VirtualBox version 4, 5 and 6
+        if output.startswith(("5", "6")):
             dumpcmd = "dumpvmcore"
         else:
             dumpcmd = "dumpguestcore"

--- a/cuckoo/private/cwd/conf/kvm.conf
+++ b/cuckoo/private/cwd/conf/kvm.conf
@@ -1,4 +1,7 @@
 [kvm]
+# Specify a libvirt URI connection string
+dsn = {{ kvm.kvm.dsn }}
+
 # Specify a comma-separated list of available machines to be used. For each
 # specified ID you have to define a dedicated section containing the details
 # on the respective machine. (E.g. cuckoo1,cuckoo2,cuckoo3)

--- a/cuckoo/private/cwd/hashes.txt
+++ b/cuckoo/private/cwd/hashes.txt
@@ -292,7 +292,10 @@ c8492c74db400e6300194c1bafd3088a102bdc8e analyzer/windows/modules/auxiliary/huma
 e86627abeb5ecc0112438ad179e9d0487870785a analyzer/windows/modules/packages/ie.py
 
 # TBD
+b327de7ae427d9e39f43d11f15b4754fc99ed98b agent/agent.py
 cb3a77d8dd7edf46de54545ca7b0c5b201f85917 analyzer/windows/bin/execsc.exe
 93727e778dadc13d83cea61a9ea88bf6b5906686 analyzer/windows/modules/auxiliary/human.py
+24cbd18428df8dbc6b9ccd7896d066c492f6d381 analyzer/windows/modules/packages/ps1.py
 6e6680e26bf1cf41909a4efcbd86917cf4b14603 analyzer/windows/modules/packages/pub.py
 d8fce614d615f6bdb3117e92bfa6e4ae2b48ea52 analyzer/windows/modules/packages/vbs.py
+f81e71f788149039f31c9b0b5e2891733e51b5d7 whitelist/ip.txt

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -26,7 +26,7 @@ from cuckoo.common.exceptions import CuckooProcessingError
 from cuckoo.common.irc import ircMessage
 from cuckoo.common.objects import File
 from cuckoo.common.utils import convert_to_printable
-from cuckoo.common.whitelist import is_whitelisted_domain
+from cuckoo.common.whitelist import is_whitelisted_domain, is_whitelisted_ip
 from cuckoo.misc import mkdir
 
 # Be less verbose about httpreplay logging messages.
@@ -635,6 +635,9 @@ class Pcap(object):
                     offset = file.tell()
                     continue
 
+                if is_whitelisted_ip(connection["dst"]):
+                    continue
+
                 self._add_hosts(connection)
 
                 if ip.p == dpkt.ip.IP_PROTO_TCP:
@@ -764,6 +767,9 @@ class Pcap2(object):
         l = sorted(r.process(), key=lambda x: x[1])
         for s, ts, protocol, sent, recv in l:
             srcip, srcport, dstip, dstport = s
+
+            if is_whitelisted_ip(dstip):
+                continue
 
             if protocol == "smtp":
                 results["smtp_ex"].append({

--- a/cuckoo/processing/virustotal.py
+++ b/cuckoo/processing/virustotal.py
@@ -53,13 +53,6 @@ class VirusTotal(Processing):
                 "Unsupported task category: %s" % self.task["category"]
             )
 
-        # Scan any dropped files that have an interesting filetype.
-        for row in self.results.get("dropped", []):
-            if not self.should_scan_file(row["type"]):
-                continue
-
-            row["virustotal"] = self.scan_file(row["path"], summary=True)
-
         return results
 
     def scan_file(self, filepath, summary=False):

--- a/cuckoo/web/templates/analysis/pages/static/index.html
+++ b/cuckoo/web/templates/analysis/pages/static/index.html
@@ -27,6 +27,12 @@
                                 <div class="tab-pane fade in active" id="static_analysis_tab">
                                     {% if "PE32" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_pe32.html" %}
+                                    {% elif "MS-DOS executable" in report.analysis.target.file.type %}
+                    			{% for sig in report.analysis.static.peid_signatures %}
+                        			{% if forloop.first and "FSG" in sig %}
+                                                	{% include "analysis/pages/static/_pe32.html" %}
+                        			{% endif %}
+                    			{% endfor %}
                                     {% elif "ELF" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_elf.html" %}
                                     {% elif "office" in report.analysis.static %}

--- a/cuckoo/web/templates/analysis/pages/static/index.html
+++ b/cuckoo/web/templates/analysis/pages/static/index.html
@@ -27,7 +27,13 @@
                                 <div class="tab-pane fade in active" id="static_analysis_tab">
                                     {% if "PE32" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_pe32.html" %}
-                                    {% elif "ELF" in report.analysis.target.file.type %}
+                                    {% elif "MS-DOS executable" in report.analysis.target.file.type %}
+                    			{% for sig in report.analysis.static.peid_signatures %}
+                        			{% if forloop.first and "FSG" in sig %}
+                                               		{% include "analysis/pages/static/_pe32.html" %}
+                        			{% endif %}
+                    			{% endfor %}                                    
+				    {% elif "ELF" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_elf.html" %}
                                     {% elif "office" in report.analysis.static %}
                                         {% include "analysis/pages/static/_office.html" %}

--- a/cuckoo/web/templates/analysis/pages/static/index.html
+++ b/cuckoo/web/templates/analysis/pages/static/index.html
@@ -27,13 +27,7 @@
                                 <div class="tab-pane fade in active" id="static_analysis_tab">
                                     {% if "PE32" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_pe32.html" %}
-                                    {% elif "MS-DOS executable" in report.analysis.target.file.type %}
-                    			{% for sig in report.analysis.static.peid_signatures %}
-                        			{% if forloop.first and "FSG" in sig %}
-                                               		{% include "analysis/pages/static/_pe32.html" %}
-                        			{% endif %}
-                    			{% endfor %}                                    
-				    {% elif "ELF" in report.analysis.target.file.type %}
+                                    {% elif "ELF" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_elf.html" %}
                                     {% elif "office" in report.analysis.static %}
                                         {% include "analysis/pages/static/_office.html" %}

--- a/docs/book/customization/machinery.rst
+++ b/docs/book/customization/machinery.rst
@@ -106,6 +106,13 @@ this base class and specify your connection string, as in the example below:
         # Set connection string.
         dsn = "my:///connection"
 
+
+Starting with Cuckoo 2.0.7a1 you can use a custom dsn by setting it in the kvm.conf file.
+Example:
+
+    dsn = qemu+ssh://192.168.56.1/system
+
+
 This works for all the virtualization technologies supported by LibVirt. Just
 remember to check if your LibVirt package (if you are using one, for example
 from your Linux distribution) is compiled with the support for the technology

--- a/docs/book/usage/api.rst
+++ b/docs/book/usage/api.rst
@@ -159,6 +159,8 @@ each one. For details click on the resource name.
 | ``GET`` :ref:`tasks_report`         | Returns the report generated out of the analysis of the task associated with the specified ID.                   |
 |                                     | You can optionally specify which report format to return, if none is specified the JSON report will be returned. |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
+| ``GET`` :ref:`tasks_summary`        | Returns a condensed report in JSON format.                                                                       |
++-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_shots`          | Retrieves one or all screenshots associated with a given analysis task ID.                                       |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_rereport`       | Re-run reporting for task associated with a given analysis task ID.                                              |
@@ -679,6 +681,30 @@ Returns the report associated with the specified task ID.
 
 * ``200`` - no error
 * ``400`` - invalid report format
+* ``404`` - report not found
+
+.. _tasks_summary:
+
+/tasks/summary
+--------------
+
+**GET /tasks/summary/** *(int: id)*
+
+Returns a condensed report associated with the specified task ID in JSON format.
+
+**Example request**.
+
+.. code-block:: bash
+
+    curl http://localhost:8090/tasks/summary/1
+
+**Parameters**:
+
+* ``id`` *(required)* *(int)* - ID of the task to get the report for
+
+**Status codes**:
+
+* ``200`` - no error
 * ``404`` - report not found
 
 .. _tasks_shots:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1173,6 +1173,11 @@ def test_migration_206_210():
     Files.create(cwd("conf"), "auxiliary.conf", """
 [replay]
     """)
+    Files.create(cwd("conf"), "kvm.conf", """
+[kvm]
+machines = cuckoo1
+interface = virbr0
+    """)
     cfg = Config.from_confdir(cwd("conf"), loose=True)
     cfg = migrate(cfg, "2.0.6", "2.1.0")
 
@@ -1180,6 +1185,8 @@ def test_migration_206_210():
     assert cfg["cuckoo"]["cuckoo"]["api_token"] is None
     assert cfg["cuckoo"]["cuckoo"]["web_secret"] is None
     assert cfg["processing"]["irma"]["probes"] is None
+    assert cfg["kvm"]["kvm"]["dsn"] == "qemu:///system"
+
 
 class FullMigration(object):
     DIRPATH = None


### PR DESCRIPTION
Hi cuckoo team

Nice to see you again.
I may have found a strange code in virustotal.py

The VT result of dropped PE binaries was saved to row['virustotal'].
The valuable "row" is a local variable in a for loop. 
Thus, it is not reduced to "results".
The code was just the function only uploading the dropped files to VT for specific user which they set "scan = yes" on their configuration.

On the other hands, malware sometimes drops a lot of PE32/MS-DOS binaries.
It will cause to waste the api license in many cases.

If all of the VT results should be saved at default automatically, 
I think we had better reduce the data stored in "results".

Kind Regards,
Tatsuya


