### PR TITLE
Support for dump memory on virtualbox 6

### DIFF
--- a/cuckoo/machinery/virtualbox.py
+++ b/cuckoo/machinery/virtualbox.py
@@ -358,7 +358,7 @@ class VirtualBox(Machinery):
             )
 
         # VirtualBox version 4, 5 and 6
-        if output.startswith("5") or output.startwith("6"):
+        if output.startswith(("5", "6")):
             dumpcmd = "dumpvmcore"
         else:
             dumpcmd = "dumpguestcore"

--- a/cuckoo/machinery/virtualbox.py
+++ b/cuckoo/machinery/virtualbox.py
@@ -357,8 +357,8 @@ class VirtualBox(Machinery):
                 "VBoxManage failed to return its version: %s" % e
             )
 
-        # VirtualBox version 4 and 5.
-        if output.startswith("5"):
+        # VirtualBox version 4, 5 and 6
+        if output.startswith("5") or output.startwith("6"):
             dumpcmd = "dumpvmcore"
         else:
             dumpcmd = "dumpguestcore"


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:  Modification in the file machinery/virtualbox to add dump memory in the version 6 of virtualbox

##### The goal of my change is: Support for Virtualbox 6 memory dump

##### What I have tested about my change is: With this change you can now use virtualbox 6 with full memory dumps
