### PR TITLE
Ability to whitelist ips

### DIFF
--- a/cuckoo/common/whitelist.py
+++ b/cuckoo/common/whitelist.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 Cuckoo Foundation.
+# Copyright (C) 2015-2019 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
@@ -7,20 +7,33 @@ import os.path
 from cuckoo.misc import cwd
 
 domains = set()
+ips = set()
+
+def _load_whitelist(wlset, wl_file):
+    for b in (True, False):
+        private = {"private": True} if b else {}
+        wl_path = cwd("whitelist", wl_file, **private)
+        if not os.path.isfile(wl_path):
+            continue
+
+        with open(wl_path, "rb") as fp:
+            whitelist = fp.read()
+
+        for entry in whitelist.split("\n"):
+            entry = entry.strip()
+            if entry and not entry.startswith("#"):
+                wlset.add(entry)
 
 def is_whitelisted_domain(domain):
-    # Initialize the domain whitelist.
     if not domains:
-        for line in open(cwd("whitelist", "domain.txt", private=True), "rb"):
-            if not line.strip() or line.startswith("#"):
-                continue
-            domains.add(line.strip())
-
-        # Collect whitelist also from $CWD if available.
-        if os.path.exists(cwd("whitelist", "domain.txt")):
-            for line in open(cwd("whitelist", "domain.txt"), "rb"):
-                if not line.strip() or line.startswith("#"):
-                    continue
-                domains.add(line.strip())
+        # Initialize the domain whitelist.
+        _load_whitelist(domains, "domain.txt")
 
     return domain in domains
+
+def is_whitelisted_ip(ip):
+    if not ips:
+        # Initialize the ip whitelist.
+        _load_whitelist(ips, "ip.txt")
+
+    return ip in ips

--- a/cuckoo/data/whitelist/ip.txt
+++ b/cuckoo/data/whitelist/ip.txt
@@ -1,0 +1,1 @@
+# You can add whitelisted IPs here.

--- a/cuckoo/private/cwd/hashes.txt
+++ b/cuckoo/private/cwd/hashes.txt
@@ -298,3 +298,4 @@ cb3a77d8dd7edf46de54545ca7b0c5b201f85917 analyzer/windows/bin/execsc.exe
 24cbd18428df8dbc6b9ccd7896d066c492f6d381 analyzer/windows/modules/packages/ps1.py
 6e6680e26bf1cf41909a4efcbd86917cf4b14603 analyzer/windows/modules/packages/pub.py
 d8fce614d615f6bdb3117e92bfa6e4ae2b48ea52 analyzer/windows/modules/packages/vbs.py
+f81e71f788149039f31c9b0b5e2891733e51b5d7 whitelist/ip.txt

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -26,7 +26,7 @@ from cuckoo.common.exceptions import CuckooProcessingError
 from cuckoo.common.irc import ircMessage
 from cuckoo.common.objects import File
 from cuckoo.common.utils import convert_to_printable
-from cuckoo.common.whitelist import is_whitelisted_domain
+from cuckoo.common.whitelist import is_whitelisted_domain, is_whitelisted_ip
 from cuckoo.misc import mkdir
 
 # Be less verbose about httpreplay logging messages.
@@ -635,6 +635,9 @@ class Pcap(object):
                     offset = file.tell()
                     continue
 
+                if is_whitelisted_ip(connection["dst"]):
+                    continue
+
                 self._add_hosts(connection)
 
                 if ip.p == dpkt.ip.IP_PROTO_TCP:
@@ -764,6 +767,9 @@ class Pcap2(object):
         l = sorted(r.process(), key=lambda x: x[1])
         for s, ts, protocol, sent, recv in l:
             srcip, srcport, dstip, dstport = s
+
+            if is_whitelisted_ip(dstip):
+                continue
 
             if protocol == "smtp":
                 results["smtp_ex"].append({


### PR DESCRIPTION
Adding IPs to $CWD/whitelist/ip.txt will cause them to
be ignored during network processing.