### PR TITLE
Fix/recursive plugins

### DIFF
--- a/cuckoo/core/plugins.py
+++ b/cuckoo/core/plugins.py
@@ -7,6 +7,7 @@ import os
 import importlib
 import inspect
 import logging
+import pkgutil
 
 import cuckoo
 
@@ -34,18 +35,14 @@ def enumerate_plugins(dirpath, module_prefix, namespace, class_,
     if os.path.isfile(dirpath):
         dirpath = os.path.dirname(dirpath)
 
-    for fname in os.listdir(dirpath):
-        if fname.endswith(".py") and not fname.startswith("__init__"):
-            module_name, _ = os.path.splitext(fname)
-            try:
-                importlib.import_module(
-                    "%s.%s" % (module_prefix, module_name)
-                )
-            except ImportError as e:
-                raise CuckooOperationalError(
-                    "Unable to load the Cuckoo plugin at %s: %s. Please "
-                    "review its contents and/or validity!" % (fname, e)
-                )
+    for _, module_name, _ in pkgutil.iter_modules(dirpath, module_prefix):
+        try:
+            importlib.import_module(module_name)
+        except ImportError as e:
+            raise CuckooOperationalError(
+                "Unable to load the Cuckoo plugin at %s: %s. Please "
+                "review its contents and/or validity!" % (module_name, e)
+            )
 
     subclasses = class_.__subclasses__()[:]
 
@@ -59,9 +56,9 @@ def enumerate_plugins(dirpath, module_prefix, namespace, class_,
         subclasses.extend(subclass.__subclasses__())
 
         # Check whether this subclass belongs to the module namespace that
-        # we're currently importing. It should be noted that parent and child
+        # we're currently importing. It should be noted that parent
         # namespaces should fail the following if-statement.
-        if module_prefix != ".".join(subclass.__module__.split(".")[:-1]):
+        if not subclass.__module__.startswith(module_prefix):
             continue
 
         namespace[subclass.__name__] = subclass
@@ -73,7 +70,8 @@ def enumerate_plugins(dirpath, module_prefix, namespace, class_,
     if as_dict:
         ret = {}
         for plugin in plugins:
-            ret[plugin.__module__.split(".")[-1]] = plugin
+            plugin_module = plugin.__module__.split(".")[len(module_prefix) + 1:]
+            ret[plugin_module] = plugin
         return ret
 
     return sorted(plugins, key=lambda x: x.__name__.lower())

--- a/cuckoo/core/plugins.py
+++ b/cuckoo/core/plugins.py
@@ -35,7 +35,7 @@ def enumerate_plugins(dirpath, module_prefix, namespace, class_,
     if os.path.isfile(dirpath):
         dirpath = os.path.dirname(dirpath)
 
-    for _, module_name, _ in pkgutil.iter_modules(dirpath, module_prefix):
+    for _, module_name, _ in pkgutil.iter_modules([dirpath], module_prefix+"."):
         try:
             importlib.import_module(module_name)
         except ImportError as e:
@@ -70,7 +70,7 @@ def enumerate_plugins(dirpath, module_prefix, namespace, class_,
     if as_dict:
         ret = {}
         for plugin in plugins:
-            plugin_module = plugin.__module__.split(".")[len(module_prefix) + 1:]
+            plugin_module = plugin.__module__[len(module_prefix) + 1:]
             ret[plugin_module] = plugin
         return ret
 

--- a/tests/files/enumplugins/__init__.py
+++ b/tests/files/enumplugins/__init__.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from . import sig1, sig2, sig3
+from .sigsub import sigsub1, sigsub2
 
 class meta:
-    plugins = sig1.Sig1, sig2.Sig2, sig3.Sig3
+    plugins = sig1.Sig1, sig2.Sig2, sig3.Sig3, sigsub1.Sigsub1, sigsub2.Sigsub2

--- a/tests/files/enumplugins/sigsub/__init__.py
+++ b/tests/files/enumplugins/sigsub/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2019 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from .sigsub1 import Sigsub1
+from .sigsub2 import Sigsub2

--- a/tests/files/enumplugins/sigsub/sigsub1.py
+++ b/tests/files/enumplugins/sigsub/sigsub1.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2019 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from cuckoo.common.abstracts import Signature
+
+class Sigsub1(Signature):
+    name = "sigsub1"

--- a/tests/files/enumplugins/sigsub/sigsub2.py
+++ b/tests/files/enumplugins/sigsub/sigsub2.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2019 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from .sigsub1 import Sigsub1
+
+class Sigsub2(Sigsub1):
+    name = "sigsub2"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -24,16 +24,14 @@ def test_enumerate_plugins():
     )
     sys.path.pop(0)
 
-    assert len(plugins) == 3
-    assert plugins[0].name == "sig1"
-    assert plugins[1].name == "sig2"
-    assert plugins[2].name == "sig3"
-    assert plugins[0].foo == "bar"
-    assert plugins[1].foo == "bar"
-    assert plugins[2].foo == "bar"
+    assert len(plugins) == 5
+    assert [plugin.name for plugin in plugins] == ["sig1", "sig2", "sig3", "sigsub1", "sigsub2"]
+    assert all([plugin.foo == "bar" for plugin in plugins])
     assert issubclass(sys.modules["enumplugins"].sig1.Sig1, Signature)
     assert issubclass(sys.modules["enumplugins"].sig2.Sig2, Signature)
     assert issubclass(sys.modules["enumplugins"].sig3.Sig3, Signature)
+    assert issubclass(sys.modules["enumplugins"].sigsub.Sigsub1, Signature)
+    assert issubclass(sys.modules["enumplugins"].sigsub.Sigsub2, Signature)
 
 def test_load_signatures():
     set_cwd(tempfile.mkdtemp())
@@ -51,6 +49,8 @@ def test_load_signatures():
     assert "signatures.sig1" in names
     assert "signatures.sig2" in names
     assert "signatures.sig3" in names
+    assert "signatures.sigsub.sigsub1" in names
+    assert "signatures.sigsub.sigsub2" in names
 
     # Ensure that the Signatures are loaded in the RunSignatures object.
     RunSignatures.init_once()
@@ -60,6 +60,8 @@ def test_load_signatures():
     assert "Sig1" in names
     assert "Sig2" in names
     assert "Sig3" in names
+    assert "Sigsub1" in names
+    assert "Sigsub2" in names
 
 def test_libvirt_loaded():
     """KVM is a subclass of LibVirtMachine, which is now autoloaded as well."""


### PR DESCRIPTION

##### What I have added/changed is:
- Added support for nesting plugin packages
- Package walker uses `pkgutil.iter_modules` instead of `os.listdir`
##### The goal of my change is:

Sometimes there is a need to provide signatures for few versions of the same malware family. These signatures are usually using common code base, so keeping them in separate subpackage seems to be the most elegant way.

Example:
```
signatures
├── emotet
│   ├── __init__.py
│   ├── emotet_v4.py
│   ├── emotet_v5.py
│   ├── libs
│   │   └── ... 
```

Unfortunately, in current version - only flat structure of plugins is supported.

##### What I have tested about my change is:
- Necessary unit tests included in this PR