### PR TITLE
Enable static analysis view on WebUI if FSG2.0 packer

### DIFF
--- a/cuckoo/web/templates/analysis/pages/static/index.html
+++ b/cuckoo/web/templates/analysis/pages/static/index.html
@@ -27,6 +27,12 @@
                                 <div class="tab-pane fade in active" id="static_analysis_tab">
                                     {% if "PE32" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_pe32.html" %}
+                                    {% elif "MS-DOS executable" in report.analysis.target.file.type %}
+                    			{% for sig in report.analysis.static.peid_signatures %}
+                        			{% if forloop.first and "FSG" in sig %}
+                                                	{% include "analysis/pages/static/_pe32.html" %}
+                        			{% endif %}
+                    			{% endfor %}
                                     {% elif "ELF" in report.analysis.target.file.type %}
                                         {% include "analysis/pages/static/_elf.html" %}
                                     {% elif "office" in report.analysis.static %}


### PR DESCRIPTION
Hi cuckoo team

I created PR about the improvement of static analysis viewer.

##### What I have added/changed is:
to add FSG packer's pattern in
   cuckoo/web/templates/analysis/pages/static/index.html

Before this changes, static analysis result on WebUI is shown as " No static analysis available. " when we analyse FSG packed file.

Because FSG DoS header is like below. This doesn't include the data of PE header's offset(usually 0x40).
Thus, file type is recognised as "MS-DOS executable", however this file is PE and we could use _pe32.html. This characteristic is found on FSG 1.33 ~ 2.0 packers.

00000000  4d 5a 00 00 00 00 00 00  00 00 00 00 50 45 00 00  |MZ..........PE..|
00000010  4c 01 02 00 46 53 47 21  00 00 00 00 00 00 00 00  |L...FSG!........|
00000020  e0 00 8f 81 0b 01 00 00  00 f4 03 00 00 c2 00 00  |................|


##### The goal of my change is:
To enable cuckoo to show static analysis view on WebUI about FSG packer.

##### What I have tested about my change is:
I have tested this code on my local cuckoo 2.0.6.

Kind Regards,
Tatsuya


