### PR TITLE
Fixed pip version problem: https://github.com/cuckoosandbox/cuckoo/is…

### DIFF
--- a/cuckoo/common/utils.py
+++ b/cuckoo/common/utils.py
@@ -3,6 +3,7 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+import pkg_resources
 import base64
 import bs4
 import chardet
@@ -262,7 +263,7 @@ def exception_message():
 
     msg += "Modules: %s\n\n" % " ".join(sorted(
         "%s:%s" % (package.key, package.version)
-        for package in pip.get_installed_distributions()
+        for package in pkg_resources.working_set
     ))
     return msg
 


### PR DESCRIPTION
…sues/2678

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
I swapped one line where a non stable pip api function has been used to a stable api function call:
https://github.com/cuckoosandbox/cuckoo/issues/2678

Another Issue detailing the problem:
https://github.com/pypa/pip/issues/5243

##### The goal of my change is:
That cuckoo works with the newest version of pip