### PR TITLE
Fixing a problem where on win7_64 the zer0mon driver couldn't be load…

### DIFF
--- a/cuckoo/data/analyzer/windows/lib/core/driver.py
+++ b/cuckoo/data/analyzer/windows/lib/core/driver.py
@@ -36,7 +36,7 @@ class Driver(object):
                 "bin", "%s-x64.sys" % self.driver_name
             )
             install_dir = os.path.expandvars(
-                "%SystemRoot%\\sysnative\\drivers"
+                "%SystemRoot%\\system32\\drivers"
             )
         else:
             self.driver_path = os.path.join(


### PR DESCRIPTION
…ed because of the wrong path

##### What I have added/changed is:
A oneliner where the path to the driver loading is incorrect. 

#### The goal of my change is:
To be able to load the zer0m0n driver without problems

##### What I have tested about my change is:
