### PR TITLE
Fix an API call for recovering data from network analysis on Cuckoo web

### DIFF
--- a/cuckoo/web/src/scripts/analysis_network.js
+++ b/cuckoo/web/src/scripts/analysis_network.js
@@ -335,7 +335,7 @@ class RequestDisplay {
 
     	// this will later be replaced by the ajax call getting the content
 
-        CuckooWeb.post("/analysis/api/task/network_http_data/", {
+        CuckooWeb.api_post("/analysis/api/task/network_http_data/", {
             "task_id": window.task_id,
             "protocol": _this.protocol,
             "request_body": false,

--- a/cuckoo/web/static/js/cuckoo/analysis_network.js
+++ b/cuckoo/web/static/js/cuckoo/analysis_network.js
@@ -357,7 +357,7 @@ var RequestDisplay = function () {
 
             // this will later be replaced by the ajax call getting the content
 
-            CuckooWeb.post("/analysis/api/task/network_http_data/", {
+            CuckooWeb.api_post("/analysis/api/task/network_http_data/", {
                 "task_id": window.task_id,
                 "protocol": _this.protocol,
                 "request_body": false,


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Just change the "post" into "api_post" (and so, using JSON requests)

##### The goal of my change is:
An API call need to be made using JSON, otherwise there is a 501 error from the server

##### What I have tested about my change is:
Recompile and execute a request to recover my traffic decryption on the Cuckoo web portal