### PR TITLE
block public file download

### DIFF
--- a/cuckoo/data/web/local_settings.py
+++ b/cuckoo/data/web/local_settings.py
@@ -6,7 +6,7 @@
 import web.errors
 
 # Maximum upload size (10GB, so there's basically no limit).
-MAX_UPLOAD_SIZE = 10*1024*1024*1024
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024 * 1024
 
 # Override default secret key stored in $CWD/web/.secret_key
 # Make this unique, and don't share it with anybody.
@@ -37,3 +37,10 @@ ALLOWED_HOSTS = ["*"]
 
 handler404 = web.errors.handler404
 handler500 = web.errors.handler500
+
+#A list of strings representing the subnets or ipaddresses that can download 
+#samples and dropped files 
+#Values in this list can be ipv4 or ipv6 separated by "," 
+#(e.g. '127.0.0.0/8,10.0.0.0/8,fd00::/8').
+ALLOWED_FILEDOWNLOAD_SUBNETS = '127.0.0.0/8,10.0.0.0/8,fd00::/8'
+

--- a/cuckoo/web/utils.py
+++ b/cuckoo/web/utils.py
@@ -132,3 +132,14 @@ def normalize_task(task):
             os.path.basename(task["target"])
         )
     return task
+
+def get_client_ip(request):
+    try:
+        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(',')[0]
+        else:
+            ip = request.META.get('REMOTE_ADDR')
+        return ip
+    except Exception as e:
+        return None

--- a/cuckoo/web/web/middle.py
+++ b/cuckoo/web/web/middle.py
@@ -4,9 +4,11 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 from django.shortcuts import redirect
+from ipaddress import ip_network,ip_address
 
 from cuckoo.common.config import config
 from cuckoo.misc import version
+from cuckoo.web.utils import get_client_ip
 
 class CuckooAuthentication(object):
     def process_request(self, request):
@@ -31,3 +33,23 @@ class CuckooHeaders(object):
         response["Cache-Control"] = "no-cache"
         response["Expires"] = "0"
         return response
+
+class CuckooFileDownloadAuthentication(object):
+    def process_request(self, request):
+        if not request.path.startswith(("/file/sample/","/file/dropped/")): 
+            return
+        #if no ALLOWED_FILEDOWNLOAD_SUBNETS in web local_settings, ignore this
+        try:
+            from settings import ALLOWED_FILEDOWNLOAD_SUBNETS
+        except ImportError as e:
+            return        
+        ip = get_client_ip(request)
+        isallowed = False
+        if ip:
+            for network in ALLOWED_FILEDOWNLOAD_SUBNETS.split(','):
+                network = ip_network(unicode(network),strict=False)
+                if ip_address(unicode(ip)) in network:
+                    isallowed = True
+                    return
+        if not isallowed and not request.session.get("auth"):
+            return redirect("/secret/")    

--- a/cuckoo/web/web/settings.py
+++ b/cuckoo/web/web/settings.py
@@ -110,6 +110,7 @@ MIDDLEWARE_CLASSES = (
     "django.middleware.csrf.CsrfViewMiddleware",
     # Cuckoo Authentication & headers.
     "web.middle.CuckooAuthentication",
+    "web.middle.CuckooFileDownloadAuthentication",
     "web.middle.CuckooHeaders",
     # Our custom exception handler.
     "web.errors.ExceptionMiddleware"


### PR DESCRIPTION
What I have added/changed is: Create middleware that blocks file download if ipv4 or ipv6 address not in allowed subnets/ip list. 
The goal of my change is: To block public download of malware samples and dropped files so only admins can download and users can't download other users' files. Not to allow users to use Cuckoo to distribute malware.  
What I have tested about my change is:  file download works if in list or no list in local settings, file download blocked if not in list. 
