### PR TITLE
Bug fix on rooter's rules for result server

### DIFF
--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -65,6 +65,7 @@ class AnalysisManager(threading.Thread):
         self.rt_table = None
         self.unrouted_network = False
         self.stopped_aux = False
+        self.rs_ip = config("cuckoo:resultserver:ip")
         self.rs_port = config("cuckoo:resultserver:port")
 
     def init(self):
@@ -210,7 +211,7 @@ class AnalysisManager(threading.Thread):
             options["file_name"] = File(self.task.target).get_name()
 
         options["id"] = self.task.id
-        options["ip"] = self.machine.resultserver_ip
+        options["ip"] = self.rs_ip
         options["port"] = self.rs_port
         options["category"] = self.task.category
         options["target"] = self.task.target
@@ -302,7 +303,7 @@ class AnalysisManager(threading.Thread):
         if self.route == "drop" or self.route == "internet":
             rooter(
                 "drop_enable", self.machine.ip,
-                config("cuckoo:resultserver:ip"),
+                str(self.rs_ip),
                 str(self.rs_port)
             )
 
@@ -319,7 +320,7 @@ class AnalysisManager(threading.Thread):
         if self.route == "tor":
             rooter(
                 "tor_enable", self.machine.ip,
-                str(config("cuckoo:resultserver:ip")),
+                str(self.rs_ip),
                 str(config("routing:tor:dnsport")),
                 str(config("routing:tor:proxyport"))
             )
@@ -354,7 +355,7 @@ class AnalysisManager(threading.Thread):
         if self.route == "drop" or self.route == "internet":
             rooter(
                 "drop_disable", self.machine.ip,
-                config("cuckoo:resultserver:ip"),
+                str(self.rs_ip),
                 str(self.rs_port)
             )
 
@@ -371,7 +372,7 @@ class AnalysisManager(threading.Thread):
         if self.route == "tor":
             rooter(
                 "tor_disable", self.machine.ip,
-                str(config("cuckoo:resultserver:ip")),
+                str(self.rs_ip),
                 str(config("routing:tor:dnsport")),
                 str(config("routing:tor:proxyport"))
             )
@@ -451,6 +452,7 @@ class AnalysisManager(threading.Thread):
             })
             return False
 
+        self.rs_ip = self.machine.resultserver_ip or ResultServer().ip
         self.rs_port = self.machine.resultserver_port or ResultServer().port
 
         # At this point we can tell the ResultServer about it.


### PR DESCRIPTION
##### What I have added/changed is:
I've added a `rs_ip` attribute in `scheduler.py` which stands for the result server IP of this analysis. This attribute is set accordingly to the parameter indicated in the machine configuration and defaults to the global result server IP, indicated in `cuckoo.conf`. It is then used in each call to the rooter process to manage `iptables`.

This code is widely inspired of what was already done for the result server port (`rs_port` in the modified file).

##### The goal of my change is:
Fixes #2769 

##### What I have tested about my change is:
I've tested it in production, it is working: the analysis can now be performed.