### PR TITLE
Rooter port filtering

### DIFF
--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -179,6 +179,19 @@ def dns_forward(action, vm_ip, dns_ip, dns_port="53"):
         "--to-destination", "%s:%s" % (dns_ip, dns_port)
     )
 
+def forward_toggle(action, src, dst, ipaddr):
+    """Toggle forwarding a specific IP address from one interface into
+    another."""
+    run_iptables(
+        action, "FORWARD", "-i", src, "-o", dst,
+        "--source", ipaddr, "-j", "ACCEPT"
+    )
+
+    run_iptables(
+        action, "FORWARD", "-i", dst, "-o", src,
+        "--destination", ipaddr, "-j", "ACCEPT"
+    )
+
 def forward_enable(src, dst, ipaddr):
     """Enable forwarding a specific IP address from one interface into
     another."""
@@ -188,28 +201,12 @@ def forward_enable(src, dst, ipaddr):
     run_iptables("-D", "FORWARD", "-i", src, "-j", "REJECT")
     run_iptables("-D", "FORWARD", "-o", src, "-j", "REJECT")
 
-    run_iptables(
-        "-A", "FORWARD", "-i", src, "-o", dst,
-        "--source", ipaddr, "-j", "ACCEPT"
-    )
-
-    run_iptables(
-        "-A", "FORWARD", "-i", dst, "-o", src,
-        "--destination", ipaddr, "-j", "ACCEPT"
-    )
+    forward_toggle("-A", src, dst, ipaddr)
 
 def forward_disable(src, dst, ipaddr):
     """Disable forwarding of a specific IP address from one interface into
     another."""
-    run_iptables(
-        "-D", "FORWARD", "-i", src, "-o", dst,
-        "--source", ipaddr, "-j", "ACCEPT"
-    )
-
-    run_iptables(
-        "-D", "FORWARD", "-i", dst, "-o", src,
-        "--destination", ipaddr, "-j", "ACCEPT"
-    )
+    forward_toggle("-D", src, dst, ipaddr)
 
 def srcroute_enable(rt_table, ipaddr):
     """Enable routing policy for specified source IP address."""

--- a/cuckoo/apps/rooter.py
+++ b/cuckoo/apps/rooter.py
@@ -221,6 +221,12 @@ def forward_toggle(action, src, dst, ipaddr, restricted_forward, allowed_ports):
                 "--source", ipaddr, "-j", "ACCEPT"
             )
 
+            run_iptables(
+                action, "FORWARD", "-i", dst, "-o", src,
+                "-m", "state", "--state", "RELATED,ESTABLISHED",
+                "--destination", ipaddr, "-j", "ACCEPT"
+            )
+
     # No restrictions for forwarding
     else:
         run_iptables(

--- a/cuckoo/auxiliary/mitm.py
+++ b/cuckoo/auxiliary/mitm.py
@@ -84,6 +84,9 @@ class MITM(Auxiliary):
             "%s:%d" % (self.machine.resultserver_ip, port)
         )
 
+        # Register listening port in oprtion, to create iptables rules
+        self.task.options["mitm_port"] = port
+
         log.info("Started mitm interception with PID %d (ip=%s, port=%d).",
                  self.proc.pid, self.machine.resultserver_ip, self.port)
 

--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -817,6 +817,11 @@ class Config(object):
                 "auto_rt": Boolean(True),
                 "drop": Boolean(False),
             },
+            "internet": {
+                "allowed_input_ports": List(String, ""),
+                "restrict_forwarded_ports": Boolean(False),
+                "allowed_forwarded_ports": List(String, ""),
+            },
             "inetsim": {
                 "enabled": Boolean(False),
                 "server": String("192.168.56.1"),

--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -947,6 +947,13 @@ class Scheduler(object):
                          "VM.", machine.name)
                 continue
 
+            # TODO: Ports forwarding filtering and input ports filtering isn't
+            #       performed here. To manage this cleaning, we must manage
+            #       differently rules in rooter because the configuration may
+            #       change between two cuckoo's starts. Thus, performing this
+            #       cleaning would require a stateful rooter, knowing which
+            #       rule is associated to which machine.
+
             # Drop forwarding rule to each VPN.
             if config("routing:vpn:enabled"):
                 for vpn in config("routing:vpn:vpns"):

--- a/cuckoo/private/cwd/conf/routing.conf
+++ b/cuckoo/private/cwd/conf/routing.conf
@@ -43,6 +43,25 @@ auto_rt = {{ routing.routing.auto_rt }}
 # is enabled anyway, it is automatically enabled.
 drop = {{ routing.routing.drop }}
 
+[internet]
+# With internet routing, Cuckoo only forwards outgoing VM traffic through the
+# 'dirty line' and DROP all ingoing traffic. This parameter configure allowed
+# INPUT ports. This can be used to have a DNS proxy installed on the host.
+# Example: udp:53,tcp:80,tcp:443
+allowed_input_ports = {{ routing.internet.allowed_input_ports }}
+
+# With internet routing, Cuckoo basically considers the outgoing traffic interface
+# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
+# parameter aims to enable ports forwarding filtering.
+restrict_forwarded_ports = {{ routing.internet.restrict_forwarded_ports }}
+
+# With internet routing, Cuckoo basically considers the outgoing traffic interface
+# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
+# parameter aims to list allowed ports that can be forwarded. It has no effect on
+# analyses if restrict_forward_ports is disabled.
+# Example: udp:53,tcp:80,tcp:443
+allowed_forwarded_ports = {{ routing.internet.allowed_forwarded_ports }}
+
 [inetsim]
 # Route a VM to your local InetSim setup (could in theory also be any other
 # type of web service / etc).

--- a/docs/book/_files/conf/routing.conf
+++ b/docs/book/_files/conf/routing.conf
@@ -43,6 +43,25 @@ auto_rt = yes
 # is enabled anyway, it is automatically enabled.
 drop = no
 
+[internet]
+# With internet routing, Cuckoo only forwards outgoing VM traffic through the
+# 'dirty line' and DROP all ingoing traffic. This parameter configure allowed
+# INPUT ports. This can be used to have a DNS proxy installed on the host.
+# Example: udp:53,tcp:80,tcp:443
+allowed_input_ports = 
+
+# With internet routing, Cuckoo basically considers the outgoing traffic interface
+# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
+# parameter aims to enable ports forwarding filtering.
+restrict_forwarded_ports = no
+
+# With internet routing, Cuckoo basically considers the outgoing traffic interface
+# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
+# parameter aims to list allowed ports that can be forwarded. It has no effect on
+# analyses if restrict_forward_ports is disabled.
+# Example: udp:53,tcp:80,tcp:443
+allowed_forwarded_ports =
+
 [inetsim]
 # Route a VM to your local InetSim setup (could in theory also be any other
 # type of web service / etc).


### PR DESCRIPTION
##### What I have added/changed is:
- support for `INPUT` filtering during analysis
- support for `FORWARD` filtering (forwarded ports filtering)

To do so, I've added some new configuration parameters and updated documentation accordingly:
```
[internet]
# With internet routing, Cuckoo only forwards outgoing VM traffic through the
# 'dirty line' and DROP all ingoing traffic. This parameter configure allowed
# INPUT ports. This can be used to have a DNS proxy installed on the host.
# Example: udp:53,tcp:80,tcp:443
allowed_input_ports = 

# With internet routing, Cuckoo basically considers the outgoing traffic interface
# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
# parameter aims to enable ports forwarding filtering.
restrict_forwarded_ports = no

# With internet routing, Cuckoo basically considers the outgoing traffic interface
# as a 'dirty line' access. This implies no filtering on outgoing traffic. This
# parameter aims to list allowed ports that can be forwarded. It has no effect on
# analyses if restrict_forward_ports is disabled.
# Example: udp:53,tcp:80,tcp:443
allowed_forwarded_ports = 
```

In addition, I've corrected a bug in `iptables` rules built for analyses: MITMproxy can now receive data from analysed VM, thanks to an `iptables` rules built just before analysis.

##### The goal of my change is:
1. Make a host service available to the analysed VM (for example a DNS cache) thanks to `INPUT` port filtering
2. Filter what is forwarded through the host during analysis, in order to "cleanify" the "dirty line"

##### What I have tested about my change is:
I've checked `iptables` rules during anlyses.

##### Important note
During scheduler's start, an `iptables` rules cleanup is performed. Ports forwarding filtering and input ports filtering cleaning aren't performed here. To manage these cleanings, we must manage differently rules in rooter because the configuration may change between two cuckoo's starts. Thus, performing these cleanings would require a stateful rooter, knowing which rule is associated to which machine. That's why I did not go further in that direction.
