### PR TITLE
Update Linux Guest Instructions for 17.04

### DIFF
--- a/docs/book/installation/guest/linux.rst
+++ b/docs/book/installation/guest/linux.rst
@@ -34,7 +34,7 @@ avoid have to start as root, e.g.::
 with your user.**
 
 
-Preparing x32/x64 Ubuntu 18.04 Linux guests
+Preparing x32/x64 Ubuntu 17.04 Linux guests
 ===========================================
 
 Ensure the agent automatically starts. The easiest way is to add it to crontab::
@@ -46,24 +46,21 @@ Install dependencies inside of the virtual machine::
 
     $ sudo apt-get install systemtap gcc patch linux-headers-$(uname -r)
 
-Install kernel debugging symbols::
+Systemtap will not properply compile on versions other than 17.04. However, 17.04 is considered EOL, and most repositories are closed down. Below is a method to bypass the EOL'd repos.
 
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C8CAB6595FDFF622
+*Warning: downloading packages off the internet is not without risks. Proceed with caution*
 
-    $ codename=$(lsb_release -cs)
-    $ sudo tee /etc/apt/sources.list.d/ddebs.list << EOF
-      deb http://ddebs.ubuntu.com/ ${codename}          main restricted universe multiverse
-      #deb http://ddebs.ubuntu.com/ ${codename}-security main restricted universe multiverse
-      deb http://ddebs.ubuntu.com/ ${codename}-updates  main restricted universe multiverse
-      deb http://ddebs.ubuntu.com/ ${codename}-proposed main restricted universe multiverse
-    EOF
+You may need to navigate to http://ddebs.ubuntu.com/dists.old/zesty/main/ , and check the release files for your arictecture before downloading a package.
 
-    $ sudo apt-get update
-    $ sudo apt-get install linux-image-$(uname -r)-dbgsym
+For example, on Ubuntu 17.04, amd64:
 
-(For Debian 9 amd64) Install kernel debugging symbols::
+Download kernel debugging symbols:
+    $ wget http://launchpadlibrarian.net/314756630/linux-image-4.10.0-19-generic-dbgsym_4.10.0-19.21_amd64.ddeb
 
-    $ sudo apt-get install linux-image-$(uname -r)-dbg
+Verify package integrity with the sha1 hash listed in the Release file:
+    $ sha1sum linux-image-4.10.0-19-generic-dbgsym_4.10.0-19.21_amd64.ddeb
+Install the debug package
+    $ sudo dpkg -i linux-image-4.10.0-19-generic-dbgsym_4.10.0-19.21_amd64.ddeb
 
 Patch the SystemTap tapset, so that the Cuckoo analyzer can properly parse the
 output::


### PR DESCRIPTION
### What I have added/changed is:

I have updated the documentation for creating a linux guest between lines 49 through 61 that corrects how to install debug packages.

##### The goal of my change is:
Ubuntu 17.04 is currently regarded as EOL. However, the provided systemtap instructions only work for version 17.04. Any version above this will result in compile-time errors for the systemtap patches. This creates a catch-22 of needing the packages without access to them.

This change shows users who _understand the risk of downloading patches from the internet rather than safely through APT_ how to secure the debug symbols for 17.04, and proceed with the directions to create a linux guest.

Per askubuntu.com/questions/1156808/ddebs-repository-looking-in-wrong-path-on-zesty-1704-sources-list-d-modificatio , I encountered this issue when using APT, and from help with a co-woker got pointed to this solution and hoped that this change will benefit other users that encounter the issue and are looking for ways to get a linux guest working.


##### What I have tested about my change is:
I have followed these new directions compeletly on a fresh installation of Ubuntu 17.04, and achieved a successful compile of stap_.ko . I also was able to get the correct output per the current docs showing a successful compile.