### PR TITLE
add CSRF exempt (fix #2789)

### DIFF
--- a/cuckoo/web/analysis/views.py
+++ b/cuckoo/web/analysis/views.py
@@ -16,7 +16,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.views.decorators.http import require_safe
-
+from django.views.decorators.csrf import csrf_exempt
 from cuckoo.core.database import Database, TASK_PENDING
 from cuckoo.common.config import config
 from cuckoo.common.elastic import elastic
@@ -357,6 +357,7 @@ def search(request):
     })
 
 @require_safe
+@csrf_exempt
 def remove(request, task_id):
     """Remove an analysis.
     @todo: remove folder from storage.


### PR DESCRIPTION
hot fix for #2789. 

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html
sure

##### What I have added/changed is:
CSRF exempt decorator.

##### The goal of my change is:
 So it is possible to actually delete a task (and its results) via API.

##### What I have tested about my change is:
not enough testing yet.