### PR TITLE
Misp screenshots

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -751,7 +751,7 @@ class Config(object):
                 "enabled": Boolean(False),
                 "url": String(),
                 "apikey": String(sanitize=True),
-                "mode": String("maldoc ipaddr hashes url"),
+                "mode": String("ipaddr hashes url"),
                 "distribution": Int(0, required=False),
                 "analysis": Int(0, required=False),
                 "threat_level": Int(4, required=False),

--- a/cuckoo/compat/config.py
+++ b/cuckoo/compat/config.py
@@ -595,7 +595,7 @@ def _20c2_200(c):
         "enabled": False,
         "url": None,
         "apikey": None,
-        "mode": "maldoc ipaddr hashes url",
+        "mode": "ipaddr hashes url",
     }
     c["reporting"]["mattermost"]["hash_url"] = False
     old_items = (

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -1,4 +1,4 @@
-# Enable or disable the available reporting modules [on/off].
+# Enable or disable the available reporting modules [yes/no].
 # If you add a custom reporting module to your Cuckoo setup, you have to add
 # a dedicated entry in this file, or it won't be executed.
 # You can also add additional options under the section of your module and

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: ipaddr hashes url.
+# separated by whitespace. Available modes: ipaddr hashes url screenshots.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: maldoc ipaddr hashes url.
+# separated by whitespace. Available modes: ipaddr hashes url.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -81,7 +81,7 @@ class MISP(Report):
         report = MISPObject("sandbox-report", strict=True)
         report.add_attribute("sandbox-type", "on-premise")
         report.add_attribute("on-premise-sandbox", "cuckoo")
-        for entry in results.get("screenshots"):
+        for entry in results.get("screenshots", []):
             filepath = entry.get("path")
             filename = os.path.basename(filepath)
             with open(filepath, "rb") as f:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -265,6 +265,26 @@ def test_misp_sample_hashes():
         comment="File submitted to Cuckoo"
     )
 
+def test_misp_screenshots():
+    r = MISP()
+    r.misp = mock.MagicMock()
+
+    r.misp.add_object.return_value = None
+    r.screenshots({
+        "screenshots": [
+            {"path": "tests/files/foo.txt"},
+        ]
+    }, {
+        "Event": {
+            "id": "0"
+        }
+    })
+    r.misp.add_object.assert_called_once()
+
+    params, dict_params = r.misp.add_object.call_args
+    event_id, report = params
+    assert event_id == "0"
+
 def test_misp_signatures():
     r = MISP()
     r.misp = mock.MagicMock()


### PR DESCRIPTION
This PR introduces the possibility to add screenshots to the MISP event created during reporting. The screenshots are added through an `sandbox-report` object (the best fitted I found). By default, this option is switched off.
It also removes traces of an old option `"maldoc"`, no longer implemented.

I tested these changes on a local cuckoo+MISP setup, and also created a new test unit. The PR [passes the tests on travis](https://travis-ci.org/zaphodef/cuckoo/builds/562488199).