### PR TITLE
Add buttons on the web interface to download and submit dropped buffers

### DIFF
--- a/cuckoo/reporting/mongodb.py
+++ b/cuckoo/reporting/mongodb.py
@@ -156,6 +156,20 @@ class MongoDB(Report):
 
         report["dropped"] = new_dropped
 
+        # Do the same for the buffers
+        new_buffer = []
+        if "buffer" in report:
+            for old_buffer in report["buffer"]:
+                new_buf = dict(old_buffer)
+                buf = File(old_buffer["path"])
+                if buf.valid():
+                    buf_id = self.store_file(buf, filename=old_buffer["name"])
+                    new_buf["object_id"] = buf_id
+
+                new_buffer.append(new_buf)
+
+        report["buffer"] = new_buffer
+
         new_extracted = []
         if "extracted" in report:
             for extracted in report["extracted"]:

--- a/cuckoo/web/controllers/submission/routes.py
+++ b/cuckoo/web/controllers/submission/routes.py
@@ -10,7 +10,8 @@ from django.shortcuts import redirect
 from cuckoo.common.exceptions import CuckooOperationalError
 from cuckoo.core.database import Database
 from cuckoo.core.submit import SubmitManager
-from cuckoo.web.utils import view_error, render_template, dropped_filepath, binary_filepath
+from cuckoo.web.utils import (view_error, render_template,
+        dropped_filepath, buffer_filepath, binary_filepath)
 
 log = logging.getLogger(__name__)
 submit_manager = SubmitManager()
@@ -50,6 +51,19 @@ class SubmissionRoutes(object):
         return render_template(
             request, "submission/presubmit.html", submit_id=submit_id
         )
+
+    @staticmethod
+    def buffer(request, task_id, sha1):
+        filepath = buffer_filepath(task_id, sha1)
+        if not filepath:
+            return view_error(request, "No such dropped file was found!")
+
+        submit_id = submit_manager.pre("files", [{
+            "name": os.path.basename(filepath),
+            "data": open(filepath, "rb"),
+        }])
+
+        return redirect("submission/pre", submit_id=submit_id)
 
     @staticmethod
     def dropped(request, task_id, sha1):

--- a/cuckoo/web/submission/urls.py
+++ b/cuckoo/web/submission/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     url(r"pre/(?P<submit_id>\d+)/$", SubmissionRoutes.presubmit, name="submission/pre"),
     url(r"^post/(?P<submit_id>\d+)", SubmissionRoutes.postsubmit, name="submission/post"),
     url(r"^re/(?P<task_id>\d+)/$", SubmissionRoutes.resubmit, name="submission/resubmit"),
+    url(r"^(?P<task_id>\d+)/buffer/(?P<sha1>[a-f0-9]{40})/$",
+        SubmissionRoutes.buffer, name="submission/buffer"),
     url(r"^(?P<task_id>\d+)/dropped/(?P<sha1>[a-f0-9]{40})/$",
         SubmissionRoutes.dropped, name="submission/dropped"),
     url(r"^api/presubmit", SubmissionApi.presubmit, name="submission/api/presubmit"),

--- a/cuckoo/web/templates/analysis/pages/dropped/dropped_buffers.html
+++ b/cuckoo/web/templates/analysis/pages/dropped/dropped_buffers.html
@@ -22,6 +22,18 @@
                                         <tr>
                                             <th class="col-md-1 text-right">Name</th>
                                             <td><b>{{file.name}}</b></td>
+                                            <div class="pull-right">
+                                                {% if file.object_id %}
+                                                    <a href="{% url "analysis.views.file" "dropped" file.object_id %}" class="btn btn-primary btn-xs">
+                                                            <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Download
+                                                    </a>
+                                                    <a href="{% url "submission/buffer" report.analysis.info.id file.sha1 %}" class="btn btn-warning btn-xs">
+                                                            <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Submit file
+                                                    </a>
+                                                {% else %}
+                                                    <div class="btn btn-default btn-xs"> Empty file or file not found</div>
+                                                {% endif %}
+                                            </div>
                                         </tr>
                                         <tr>
                                             <th class="text-right">Size</th>

--- a/cuckoo/web/templates/analysis/pages/dropped/dropped_buffers.html
+++ b/cuckoo/web/templates/analysis/pages/dropped/dropped_buffers.html
@@ -21,19 +21,21 @@
                                     <table class="table table-striped table-condensed">
                                         <tr>
                                             <th class="col-md-1 text-right">Name</th>
-                                            <td><b>{{file.name}}</b></td>
-                                            <div class="pull-right">
-                                                {% if file.object_id %}
-                                                    <a href="{% url "analysis.views.file" "dropped" file.object_id %}" class="btn btn-primary btn-xs">
-                                                            <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Download
-                                                    </a>
-                                                    <a href="{% url "submission/buffer" report.analysis.info.id file.sha1 %}" class="btn btn-warning btn-xs">
-                                                            <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Submit file
-                                                    </a>
-                                                {% else %}
-                                                    <div class="btn btn-default btn-xs"> Empty file or file not found</div>
-                                                {% endif %}
-                                            </div>
+                                            <td>
+                                                    <b>{{file.name}}</b>
+                                                    <div class="pull-right">
+                                                            {% if file.object_id %}
+                                                            <a href="{% url "analysis.views.file" "dropped" file.object_id %}" class="btn btn-primary btn-xs">
+                                                                    <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Download
+                                                            </a>
+                                                            <a href="{% url "submission/buffer" report.analysis.info.id file.sha1 %}" class="btn btn-warning btn-xs">
+                                                                    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Submit file
+                                                            </a>
+                                                            {% else %}
+                                                            <div class="btn btn-default btn-xs"> Empty file or file not found</div>
+                                                            {% endif %}
+                                                    </div>
+                                            </td>
                                         </tr>
                                         <tr>
                                             <th class="text-right">Size</th>

--- a/cuckoo/web/utils.py
+++ b/cuckoo/web/utils.py
@@ -107,6 +107,19 @@ def file_response(data, filename, content_type):
     response["Content-Disposition"] = "attachment; filename=%s" % filename
     return response
 
+def buffer_filepath(task_id, sha1):
+    record = mongo.db.analysis.find_one({
+        "info.id": int(task_id),
+        "buffer.sha1": sha1,
+    })
+
+    if not record:
+        return
+
+    for dropped in record["buffer"]:
+        if dropped["sha1"] == sha1:
+            return dropped["path"]
+
 def dropped_filepath(task_id, sha1):
     record = mongo.db.analysis.find_one({
         "info.id": int(task_id),

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -693,6 +693,16 @@ class TestWebInterface(object):
         assert len(r) == 1
         assert r[0].filesize == os.path.getsize(__file__)
 
+    @mock.patch("cuckoo.web.controllers.submission.routes.buffer_filepath")
+    def test_submission_buffer(self, p, client):
+        p.return_value = __file__
+        r = client.get("/submit/1234/buffer/" + "a"*40 + "/")
+        assert r.status_code == 302
+
+        r, _, _ = SubmitManager().get_files(1)
+        assert len(r) == 1
+        assert r[0].filesize == os.path.getsize(__file__)
+
     @mock.patch("cuckoo.web.controllers.analysis.api.CuckooFeedback")
     def test_feedback_form(self, p, client):
         p.return_value.send_form.return_value = 3


### PR DESCRIPTION
This PR adds the possibility of downloading and submitting dropped buffers from the web interface, as it is already possible for dropped files. As such, it addresses feature request #737.