### PR TITLE
Add new option to send dropped files to MISP

### DIFF
--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: maldoc ipaddr hashes url.
+# separated by whitespace. Available modes: maldoc ipaddr hashes url dropped_files.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -81,7 +81,7 @@ class MISP(Report):
                     filename=entry.get("name"),
                     filepath_or_bytes=entry.get("path"),
                     event_id=event["Event"]["id"],
-                    category="External analysis",
+                    category="Artifacts dropped",
                     comment="Dropped file",
             )
 

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ do_setup(
         "pillow==3.2",
         "pyelftools==0.24",
         "pyguacamole==0.6",
-        "pymisp==2.4.106",
+        "pymisp==2.4.111.2",
         "pymongo==3.0.3",
         "python-dateutil==2.4.2",
         "python-magic==0.4.12",

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -302,7 +302,7 @@ def test_misp_dropped_files():
 
     r.misp.upload_sample.assert_called_once_with(
         filename="foo.txt", filepath_or_bytes="tests/files/foo.txt",
-        event_id="0", category="External analysis",
+        event_id="0", category="Artifacts dropped",
         comment="Dropped file"
     )
 


### PR DESCRIPTION
This PR introduces the possibility to push the dropped files into the created MISP event. Note that we need `pymisp==2.4.111.2` which fixes a bug, see MISP/PyMISP#321. This version does not break any already in use MISP feature. This new feature has been tested on a local setup (MISP/cuckoo).

Also note we can only use deprecated methods from `pymisp`, as the new recommended methods only work on Python >= 3.6 (see [the `pymisp` documentation](https://pymisp.readthedocs.io/modules.html#pymispexpanded-python-3-6-only))