### PR TITLE
Update references to config files

### DIFF
--- a/docs/book/installation/host/configuration.rst
+++ b/docs/book/installation/host/configuration.rst
@@ -108,11 +108,11 @@ memory.conf
 ===========
 
 The Volatility tool offers a large set of plugins for memory dump analysis.
-Some of them are quite slow. The ``$CWD/conf/volatility.conf`` file let's you
+Some of them are quite slow. The ``$CWD/conf/memory.conf`` file let's you
 enable or disable plugins of your choice. To use Volatility you have to follow
 two steps:
 
- * Enable ``volatility`` in ``$CWD/conf/processing.conf``
+ * Enable ``memory`` in ``$CWD/conf/processing.conf``
  * Enable ``memory_dump`` in ``$CWD/conf/cuckoo.conf``
 
 In ``$CWD/conf/memory.conf``'s basic section you can configure the Volatility


### PR DESCRIPTION


##### What I have added/changed is:  Documentation change only.   Corrected references of volatility to memory. (volatility.conf is now memory.conf and the section in processing.conf is also now named "memory".

##### The goal of my change is:  correct documentation saves time!

##### What I have tested about my change is: nothing!
