### PR TITLE
fixes broken physical machinery since new agent

### DIFF
--- a/cuckoo/machinery/physical.py
+++ b/cuckoo/machinery/physical.py
@@ -116,6 +116,11 @@ class Physical(Machinery):
             while self._status(label) == self.RUNNING:
                 time.sleep(1)
                 continue
+            time.sleep(5)
+            # The guest is rebooting, ensure it's online again.
+            while self._status(label) != self.RUNNING:
+                time.sleep(1)
+                continue
 
     def _list(self):
         """List physical machines installed.

--- a/cuckoo/private/cwd/conf/physical.conf
+++ b/cuckoo/private/cwd/conf/physical.conf
@@ -21,6 +21,8 @@ interface = {{ physical.physical.interface }}
 # compatibility where users are still using the cronjob-style tasking, and
 # thus effectively ignore the FOG integration). The FOG functionality has only
 # been tested against the FOG 1.2.0 stable release.
+# If you do not want to use FOG, set the hostname to "none" and the machines
+# will be rebooted after the analysis.
 hostname = {{ physical.fog.hostname }}
 username = {{ physical.fog.username }}
 password = {{ physical.fog.password }}

--- a/docs/book/_files/conf/physical.conf
+++ b/docs/book/_files/conf/physical.conf
@@ -21,6 +21,8 @@ interface = eth0
 # compatibility where users are still using the cronjob-style tasking, and
 # thus effectively ignore the FOG integration). The FOG functionality has only
 # been tested against the FOG 1.2.0 stable release.
+# If you do not want to use FOG, set the hostname to "none" and the machines
+# will be rebooted after the analysis.
 hostname = none
 username = fog
 password = password

--- a/tests/files/conf/20c1_plain/physical.conf
+++ b/tests/files/conf/20c1_plain/physical.conf
@@ -21,6 +21,8 @@ interface = eth0
 # compatibility where users are still using the cronjob-style tasking, and
 # thus effectively ignore the FOG integration). The FOG functionality has only
 # been tested against the FOG 1.2.0 stable release.
+# If you do not want to use FOG, set the hostname to "none" and the machines
+# will be rebooted after the analysis.
 hostname = none
 username = fog
 password = password

--- a/tests/files/conf/20c2_plain/physical.conf
+++ b/tests/files/conf/20c2_plain/physical.conf
@@ -21,6 +21,8 @@ interface = eth0
 # compatibility where users are still using the cronjob-style tasking, and
 # thus effectively ignore the FOG integration). The FOG functionality has only
 # been tested against the FOG 1.2.0 stable release.
+# If you do not want to use FOG, set the hostname to "none" and the machines
+# will be rebooted after the analysis.
 hostname = none
 username = fog
 password = password


### PR DESCRIPTION

##### What I have added/changed is:
- Changed the dirty workaround of using RPC TimeoutServer to a cleaner code using requests.
- Updated the documentation in the configuration file to clarify FOG is not mandatory.

##### The goal of my change is:
Repair the physical machinery module to something working and not killing Cuckoo at startup.
The error was: 
```
[cuckoo.core.scheduler] INFO: Using "physical" as machine manager
[cuckoo.machinery.physical] DEBUG: Getting status for machine: test.
[cuckoo.machinery.physical] DEBUG: Received unknown exception: <ProtocolError for 1.2.3.4:8000/RPC2: 404 Not Found>.
[cuckoo] CRITICAL: CuckooCriticalError: Error initializing machines: Unknown error occurred trying to obtain the status of physical machine test. Please turn it on and check the Cuckoo Agent.
```


##### What I have tested about my change is:
- it functionally works on cuckoo v2.0.7 with a physical host

