### PR TITLE
fix for tcpdump user permission check

### DIFF
--- a/cuckoo/auxiliary/sniffer.py
+++ b/cuckoo/auxiliary/sniffer.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from stat import S_ISUID
 import subprocess
 
 from cuckoo.common.abstracts import Auxiliary
@@ -37,12 +38,12 @@ class Sniffer(Auxiliary):
                       "capture aborted", tcpdump)
             return False
 
-        # TODO: this isn't working. need to fix.
-        # mode = os.stat(tcpdump)[stat.ST_MODE]
-        # if (mode & stat.S_ISUID) == 0:
-        #    log.error("Tcpdump is not accessible from this user, "
-        #              "network capture aborted")
-        #    return
+        # Check that tcpdump has access using current account
+        mode = os.stat(tcpdump).st_mode
+        if bool(mode & S_ISUID) == True:
+            log.error("Tcpdump is not accessible from this user, "
+                      "network capture aborted")
+            return False
 
         pargs = [
             tcpdump, "-U", "-q", "-s", "0", "-n",


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
tcpdump user check against file permissions

##### The goal of my change is:
check user permission before using TCPDUMP

##### What I have tested about my change is:
Tested on Ubuntu. This will possibly have problems on windows systems, depending on how it handles the backslash in the file path. I have no way to test this at the moment.