### PR TITLE
MISP title cleanup

### DIFF
--- a/cuckoo/auxiliary/sniffer.py
+++ b/cuckoo/auxiliary/sniffer.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from stat import S_ISUID
 import subprocess
 
 from cuckoo.common.abstracts import Auxiliary
@@ -37,12 +38,12 @@ class Sniffer(Auxiliary):
                       "capture aborted", tcpdump)
             return False
 
-        # TODO: this isn't working. need to fix.
-        # mode = os.stat(tcpdump)[stat.ST_MODE]
-        # if (mode & stat.S_ISUID) == 0:
-        #    log.error("Tcpdump is not accessible from this user, "
-        #              "network capture aborted")
-        #    return
+        # Check that tcpdump has access using current account
+        mode = os.stat(tcpdump).st_mode
+        if bool(mode & S_ISUID) == True:
+            log.error("Tcpdump is not accessible from this user, "
+                      "network capture aborted")
+            return False
 
         pargs = [
             tcpdump, "-U", "-q", "-s", "0", "-n",

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -173,11 +173,19 @@ class MISP(Report):
         analysis = self.options.get("analysis") or 0
         tag = self.options.get("tag") or "Cuckoo"
 
+        # Event title cleanup
+        if results.get("target", {}).get("category") == "file":
+            f = results.get("target", {}).get("file", {}).get("name", "")
+            inf="Cuckoo File #%d: %s" % (self.task["id"], f)
+        elif results.get("target", {}).get("category") == "url":
+            u = results.get("target", {}).get("url", "")
+            inf="Cuckoo URL #%d: %s" % (self.task["id"], u)
+
         event = self.misp.new_event(
             distribution=distribution,
             threat_level_id=threat_level,
             analysis=analysis,
-            info="Cuckoo Sandbox analysis #%d" % self.task["id"]
+            info=inf,
         )
 
         # Add a specific tag to flag Cuckoo's event


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
MISP Reporting Title. Adds the file or url name to the reported MISP event to give more context while viewing in MISP

##### The goal of my change is:
To be more clear about the type of event when viewing the summary in MISP

##### What I have tested about my change is:
Various file type and URL submissions to MISP. Possibly add an 'else' catch-all for future proofing and error management?