### PR TITLE
Event title cleanup for MISP reporting

### DIFF
--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -173,11 +173,19 @@ class MISP(Report):
         analysis = self.options.get("analysis") or 0
         tag = self.options.get("tag") or "Cuckoo"
 
+        # Event title cleanup
+        if results.get("target", {}).get("category") == "file":
+            f = results.get("target", {}).get("file", {}).get("name", "")
+            inf="Cuckoo File #%d: %s" % (self.task["id"], f)
+        elif results.get("target", {}).get("category") == "url":
+            u = results.get("target", {}).get("url", "")
+            inf="Cuckoo URL #%d: %s" % (self.task["id"], u)
+
         event = self.misp.new_event(
             distribution=distribution,
             threat_level_id=threat_level,
             analysis=analysis,
-            info="Cuckoo Sandbox analysis #%d" % self.task["id"]
+            info=inf,
         )
 
         # Add a specific tag to flag Cuckoo's event


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

What I have added/changed is:
MISP Reporting Title. Adds the file or url name to the reported MISP event to give more context while viewing in MISP

The goal of my change is:
To be more clear about the type of event when viewing the summary in MISP

What I have tested about my change is:
Various file type and URL submissions to MISP. Possibly add an 'else' catch-all for future proofing and error management?