### PR TITLE
Misp rework

### DIFF
--- a/cuckoo/common/config.py
+++ b/cuckoo/common/config.py
@@ -751,7 +751,7 @@ class Config(object):
                 "enabled": Boolean(False),
                 "url": String(),
                 "apikey": String(sanitize=True),
-                "mode": String("maldoc ipaddr hashes url"),
+                "mode": String("ipaddr hashes url"),
                 "distribution": Int(0, required=False),
                 "analysis": Int(0, required=False),
                 "threat_level": Int(4, required=False),

--- a/cuckoo/compat/config.py
+++ b/cuckoo/compat/config.py
@@ -595,7 +595,7 @@ def _20c2_200(c):
         "enabled": False,
         "url": None,
         "apikey": None,
-        "mode": "maldoc ipaddr hashes url",
+        "mode": "ipaddr hashes url",
     }
     c["reporting"]["mattermost"]["hash_url"] = False
     old_items = (

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -1,4 +1,4 @@
-# Enable or disable the available reporting modules [on/off].
+# Enable or disable the available reporting modules [yes/no].
 # If you add a custom reporting module to your Cuckoo setup, you have to add
 # a dedicated entry in this file, or it won't be executed.
 # You can also add additional options under the section of your module and

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: ipaddr hashes url.
+# separated by whitespace. Available modes: ipaddr hashes url screenshots.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: maldoc ipaddr hashes url.
+# separated by whitespace. Available modes: ipaddr hashes url.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/private/cwd/conf/reporting.conf
+++ b/cuckoo/private/cwd/conf/reporting.conf
@@ -28,7 +28,7 @@ url = {{ reporting.misp.url }}
 apikey = {{ reporting.misp.apikey }}
 
 # The various modes describe which information should be submitted to MISP,
-# separated by whitespace. Available modes: maldoc ipaddr hashes url.
+# separated by whitespace. Available modes: maldoc ipaddr hashes url dropped_files.
 mode = {{ reporting.misp.mode }}
 
 distribution = {{ reporting.misp.distribution }}

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -73,10 +73,10 @@ class MISP(Report):
     def family(self, results, event):
         for config in results.get("metadata", {}).get("cfgextr", []):
             self.misp.add_detection_name(
-                event, config["family"], "External analysis"
+                event, config["family"], "Payload type"
             )
             for cnc in config.get("cnc", []):
-                self.misp.add_url(event, cnc)
+                self.misp.add_url(event, cnc, comment="cnc")
             for url in config.get("url", []):
                 self.misp.add_url(event, url)
             for mutex in config.get("mutex", []):
@@ -123,14 +123,15 @@ class MISP(Report):
             markslist = ", ".join([x for x in marks if x and x != " "])
 
             data = "%s - (%s)" % (sig["description"], markslist)
-            self.misp.add_internal_comment(event, data)
+            self.misp.add_internal_comment(event, data, category="External analysis")
             for att, description in sig["ttp"].items():
                 if not description:
                     log.warning("Description for %s is not found", att)
                     continue
 
                 self.misp.add_internal_comment(
-                    event, "TTP: %s, short: %s" % (att, description["short"])
+                    event, "TTP: %s, short: %s" % (att, description["short"]),
+                    category="External analysis"
                 )
 
     def run(self, results):
@@ -193,7 +194,7 @@ class MISP(Report):
                     filename=os.path.basename(self.task["target"]),
                     filepath_or_bytes=self.task["target"],
                     event_id=event["Event"]["id"],
-                    category="External analysis",
+                    category="Payload delivery",
                 )
 
         self.signature(results, event)

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -81,7 +81,7 @@ class MISP(Report):
                     filename=entry.get("name"),
                     filepath_or_bytes=entry.get("path"),
                     event_id=event["Event"]["id"],
-                    category="External analysis",
+                    category="Artifacts dropped",
                     comment="Dropped file",
             )
 

--- a/cuckoo/reporting/misp.py
+++ b/cuckoo/reporting/misp.py
@@ -81,7 +81,7 @@ class MISP(Report):
         report = MISPObject("sandbox-report", strict=True)
         report.add_attribute("sandbox-type", "on-premise")
         report.add_attribute("on-premise-sandbox", "cuckoo")
-        for entry in results.get("screenshots"):
+        for entry in results.get("screenshots", []):
             filepath = entry.get("path")
             filename = os.path.basename(filepath)
             with open(filepath, "rb") as f:

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ do_setup(
         "pillow==3.2",
         "pyelftools==0.24",
         "pyguacamole==0.6",
-        "pymisp==2.4.106",
+        "pymisp==2.4.111.2",
         "pymongo==3.0.3",
         "python-dateutil==2.4.2",
         "python-magic==0.4.12",

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -265,6 +265,26 @@ def test_misp_sample_hashes():
         comment="File submitted to Cuckoo"
     )
 
+def test_misp_screenshots():
+    r = MISP()
+    r.misp = mock.MagicMock()
+
+    r.misp.add_object.return_value = None
+    r.screenshots({
+        "screenshots": [
+            {"path": "tests/files/foo.txt"},
+        ]
+    }, {
+        "Event": {
+            "id": "0"
+        }
+    })
+    r.misp.add_object.assert_called_once()
+
+    params, dict_params = r.misp.add_object.call_args
+    event_id, report = params
+    assert event_id == "0"
+
 def test_misp_signatures():
     r = MISP()
     r.misp = mock.MagicMock()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -302,7 +302,7 @@ def test_misp_dropped_files():
 
     r.misp.upload_sample.assert_called_once_with(
         filename="foo.txt", filepath_or_bytes="tests/files/foo.txt",
-        event_id="0", category="External analysis",
+        event_id="0", category="Artifacts dropped",
         comment="Dropped file"
     )
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -277,17 +277,22 @@ def test_misp_signatures():
 
     assert r.misp.add_internal_comment.call_count == 36
     r.misp.add_internal_comment.assert_has_calls([
-        mock.call("event", "Creates a service - (T1031, CreateServiceW)"),
+        mock.call("event", "Creates a service - (T1031, CreateServiceW)",
+                  category="External analysis"),
         mock.call("event", "Searches running processes potentially to identify"
                            " processes for sandbox evasion, code injection or"
                            " memory dumping -"
-                           " (T1057, Process32FirstW, Process32NextW)"),
-        mock.call("event", "TTP: T1054, short: Indicator Blocking"),
+                           " (T1057, Process32FirstW, Process32NextW)",
+                  category="External analysis"),
+        mock.call("event", "TTP: T1054, short: Indicator Blocking",
+                  category="External analysis"),
         mock.call("event", "Disables Windows Security features -"
                            " (T1089, T1112, attempts to disable user access"
-                           " control)"),
+                           " control)",
+                  category="External analysis"),
         mock.call("event", "Communicates with host for which no DNS query was"
-                           " performed - (200.87.164.69)")
+                           " performed - (200.87.164.69)",
+                  category="External analysis")
     ], any_order=True)
 
 def test_misp_all_urls():
@@ -389,14 +394,14 @@ def test_misp_family():
 
     assert r.misp.add_detection_name.call_count == 3
     r.misp.add_detection_name.assert_has_calls([
-        mock.call("event", "3x4mpl3", "External analysis"),
-        mock.call("event", "3x4mpl3_2", "External analysis"),
-        mock.call("event", "3x4mpl3_3", "External analysis")
+        mock.call("event", "3x4mpl3", "Payload type"),
+        mock.call("event", "3x4mpl3_2", "Payload type"),
+        mock.call("event", "3x4mpl3_3", "Payload type")
     ])
 
     assert r.misp.add_url.call_count == 2
     r.misp.add_url.assert_has_calls([
-        mock.call("event", "example.com/gate.php"),
+        mock.call("event", "example.com/gate.php", comment="cnc"),
         mock.call("event", "http://example.org")
     ])
 


### PR DESCRIPTION
Fusion of 3 previous PRs:
- #2805: possibility to add screenshots to the MISP, also remove traces of an old option "maldoc", no longer implemented.
- #2813: possibility to push the dropped files into the created MISP event. Note that we need pymisp==2.4.111.2 which fixes a bug, see MISP/PyMISP#321
- #2815: cosmetic changes to respect the [MISP recommendations on categories](https://www.circl.lu/doc/misp/categories-and-types/#categories).