### PR TITLE
add @csrf_exempt decorators to two views, without this 'remote contro…

### DIFF
--- a/cuckoo/web/controllers/analysis/api.py
+++ b/cuckoo/web/controllers/analysis/api.py
@@ -14,6 +14,7 @@ import zipfile
 
 from django.http import JsonResponse, HttpResponse
 from wsgiref.util import FileWrapper
+from django.views.decorators.csrf import csrf_exempt
 
 from cuckoo.common.exceptions import CuckooFeedbackError
 from cuckoo.common.files import Folders
@@ -89,6 +90,7 @@ class AnalysisApi(object):
             return json_error_response(str(e))
 
     @api_post
+    @csrf_exempt
     def tasks_info(request, body):
         task_ids = body.get("task_ids", [])
         if not list_of_ints(task_ids):

--- a/cuckoo/web/controllers/analysis/control/api.py
+++ b/cuckoo/web/controllers/analysis/control/api.py
@@ -17,6 +17,7 @@ from cuckoo.core.database import Database
 from cuckoo.reporting.mongodb import MongoDB
 from cuckoo.misc import cwd
 from cuckoo.web.utils import json_error_response, api_post
+from django.views.decorators.csrf import csrf_exempt
 
 # TODO Yes, this is far from optimal. In the future we should find a better
 # way to get results from the Cuckoo Web Interface to the analysis report (or
@@ -35,6 +36,7 @@ pending_read_request = threading.Event()
 
 class ControlApi(object):
     @staticmethod
+    @csrf_exempt
     def tunnel(request, task_id):
         task = db.view_task(int(task_id))
         if not task:


### PR DESCRIPTION
##### Description

The 'Remote Control' feature is not working when installing Cuckoo from the git master branch. 

Specifically when debugging the problem using the developer console, requests to `/analysis/<analysis id>/control/tunnel/?connect` and to `/analysis/api/tasks/info/` show a 403 error with a django CSRF_VALIDATION error.


##### What I have added/changed is:
`@csrf_exempt` decorators per Django documentation: [https://docs.djangoproject.com/en/2.2/ref/csrf/](https://docs.djangoproject.com/en/2.2/ref/csrf/)

##### The goal of my change is:
Prevent CSRF checks by Django as a CSRF attack does not make sense in this context. The requests do not affect change on the server and do not give a potential attacker ability to gain or affect data to a malicious end. 

##### What I have tested about my change is:
I have implemented the change in a branch I created for this purpose, I then installed cuckoo from this branch and made sure the 'remote control' feature works without a problem.
