### PR TITLE
Link PCAP In Moloch On Network Analysis Page

### DIFF
--- a/cuckoo/web/analysis/urls.py
+++ b/cuckoo/web/analysis/urls.py
@@ -42,7 +42,8 @@ urlpatterns = [
         r"/(?P<ip>[\d\.]+)?/(?P<host>[ a-zA-Z0-9-_\.]+)?"
         r"/(?P<src_ip>[a-zA-Z0-9\.]+)?/(?P<src_port>\d+|None)?"
         r"/(?P<dst_ip>[a-zA-Z0-9\.]+)?/(?P<dst_port>\d+|None)?"
-        r"/(?P<sid>\d+)?",
+        r"/(?P<sid>\d+)?"
+        r"/(?P<id>\d+)?",
         views.moloch),
     url(r"^import/$", SubmissionRoutes.import_, name="analysis/import"),
     # url(r"^api/tasks/list/$", AnalysisApi.tasks_list),

--- a/cuckoo/web/analysis/views.py
+++ b/cuckoo/web/analysis/views.py
@@ -248,6 +248,7 @@ moloch_mapper = {
     "dst_ip": "ip == %s",
     "dst_port": "port == %s",
     "sid": 'tags == "sid:%s"',
+    "id": "tags == cuckoo:%s"
 }
 
 @require_safe

--- a/cuckoo/web/templates/analysis/pages/network/index.html
+++ b/cuckoo/web/templates/analysis/pages/network/index.html
@@ -12,7 +12,7 @@
                 {% if report.analysis.network.pcap_id %}
                 <div class="header-right valign-bottom">
                     <a href="{% url "analysis.views.file" "pcap" report.analysis.network.pcap_id %}" title="Download pcap file"><i class="fa fa-download"></i> Download pcap</a>
-                    <a href="{% url "analysis.views.moloch" report.analysis.info.id %}" title="Open in Moloch">Moloch</a>
+                    <a href="{% url "analysis.views.moloch" report.analysis.info.id %}" title="Open in Moloch" target="_blank">Moloch</a>
                 </div>
                 {% endif %}
             </header>

--- a/cuckoo/web/templates/analysis/pages/network/index.html
+++ b/cuckoo/web/templates/analysis/pages/network/index.html
@@ -12,6 +12,7 @@
                 {% if report.analysis.network.pcap_id %}
                 <div class="header-right valign-bottom">
                     <a href="{% url "analysis.views.file" "pcap" report.analysis.network.pcap_id %}" title="Download pcap file"><i class="fa fa-download"></i> Download pcap</a>
+                    <a href="{% url "analysis.views.moloch" report.analysis.info.id %}" title="Open in Moloch">Moloch</a>
                 </div>
                 {% endif %}
             </header>


### PR DESCRIPTION
Add a link to the network analysis page next to the download PCAP link that would open up all network traffic in Moloch tagged with the cuckoo report.analysis.info.id