### PR TITLE
Fix bug: "Netlog client requested banned path: logs/all.stap"

### DIFF
--- a/cuckoo/core/resultserver.py
+++ b/cuckoo/core/resultserver.py
@@ -46,7 +46,7 @@ def netlog_sanitize_fname(path):
     """Validate agent-provided path for result files"""
     path = path.replace("\\", "/")
     dir_part, name = os.path.split(path)
-    if dir_part not in RESULT_UPLOADABLE:
+    if dir_part not in RESULT_DIRECTORIES:
         raise CuckooOperationalError("Netlog client requested banned path: %r"
                                      % path)
     if any(c in BANNED_PATH_CHARS for c in name):


### PR DESCRIPTION
##### What I have added/changed is:
change line 49 of resultserver.py from "if dir_part not in RESULT_UPLOADABLE:" to "if dir_part not in RESULT_DIRECTORIES:". 
##### The goal of my change is:
Fix bug: resultserver always bans to receive all.stap from guest Linux. This issue was also found in #2823. 
##### What I have tested about my change is:
The code works well for the sample analysis in guest Linux.