### PR TITLE
Update procmon.py

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/auxiliary/procmon.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/procmon.py
@@ -64,4 +64,4 @@ class Procmon(Auxiliary):
         ])
 
         # Upload the XML file to the host.
-        upload_to_host(self.procmon_xml, os.path.join("logs", "procmon.xml"))
+        upload_to_host(self.procmon_xml, os.path.join("files", "procmon.xml"))


### PR DESCRIPTION
Path `logs` is not writable (as is coded in [resultserver.py](https://github.com/cuckoosandbox/cuckoo/blob/master/cuckoo/core/resultserver.py), it is not in the `RESULT_UPLOADABLE` list). I think it should be uploaded to `files`.

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

I have changed the upload directory to `files` (instead `logs`)

##### The goal of my change is:

Enable uploading results (now, it fails like happens in #2823 ). Everything trying to upload anywhere not listed in `RESULT_UPLOADABLE`, will fail:

```
2020-03-13 23:22:55,599 [cuckoo.core.resultserver] ERROR: Netlog client requested banned path: 'logs/procmon.xml'
```

##### What I have tested about my change is:

I have changed it in my local code, and now it works correctly :)