### PR TITLE
Add package_files path to allowed uploadable paths

### DIFF
--- a/cuckoo/core/resultserver.py
+++ b/cuckoo/core/resultserver.py
@@ -34,7 +34,8 @@ BUFSIZE = 16 * 1024
 
 # Directories in which analysis-related files will be stored; also acts as
 # whitelist
-RESULT_UPLOADABLE = ("files", "shots", "buffer",  "extracted", "memory")
+RESULT_UPLOADABLE = ("files", "shots", "buffer",  "extracted", "memory",
+                     "package_files")
 RESULT_DIRECTORIES = RESULT_UPLOADABLE + ("reports", "logs")
 
 # Prevent malicious clients from using potentially dangerous filenames


### PR DESCRIPTION
In resultserver.py, add 'package_files' to the list of uploadable paths.
This path is used in 'analyzer.py' (both linux and windows versions) when
uploading files reported by the 'package_files' method.

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

##### The goal of my change is:

##### What I have tested about my change is:

Tested the reproduction instruction in the issue. Reproduced without the change. Got correct results with the change.

Closes: #3030 