### PR TITLE
change chart title: Free disk space -> Disk usage

### DIFF
--- a/cuckoo/web/templates/dashboard/index.html
+++ b/cuckoo/web/templates/dashboard/index.html
@@ -155,7 +155,7 @@
             <section class="dashboard-module__body free-disk-space">
 
                 <div class="dashboard-module__body--flex">
-                    <h5>Free disk space</h5>
+                    <h5>Disk usage</h5>
                     <div class="free-disk-space__chart" id="ds-stat">
                         <canvas></canvas>
                         <div class="free-disk-space__legend">


### PR DESCRIPTION
Changed title "Free disk space" for "Disk usage".
Given that we have a pie chart which shows both used and free disk, the correct label for the pie chart is Disk usage.
Also this keeps the pie chart consistent with the other chart of "Memory usage".
![image](https://user-images.githubusercontent.com/649929/81860574-516f1700-953d-11ea-899e-2c37fecdc59f.png)
