### PR TITLE
Gate: Lock werkzeug to version 0.16.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ install:
   - pip install -e .
   - pip install pytest==4.1.1 pytest-cov codecov coveralls distorm3 pycrypto
   - pip install flask-testing mock pytest-django pytest-pythonpath responses
+  - pip install werkzeug==0.16.1
 
   # Install Volatility.
   - git clone https://github.com/volatilityfoundation/volatility vol-setup


### PR DESCRIPTION
In the travis script, lock werkzeug to version 0.16.1, following #3000.

Related: #3000

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

##### The goal of my change is:

##### What I have tested about my change is:
