### PR TITLE
Updated distributor task API

### DIFF
--- a/cuckoo/distributed/views/api.py
+++ b/cuckoo/distributed/views/api.py
@@ -295,6 +295,10 @@ def task_get(task_id):
         node_id=task.node_id,
         task_id=task.task_id,
         status=task.status,
+        submitted=task.submitted,
+        delegated=task.delegated,
+        started=task.started,
+        completed=task.completed,
     )})
 
 @blueprint.route("/task/<int:task_id>", methods=["DELETE"])


### PR DESCRIPTION
Added various timestamp (submitted, completed, delegated and started) associated with cuckoo task in response of /api/task/<id> API.

##### What I have added/changed is:
Updated cuckoo distributor task GET api to return various timestamps associated with task. After this change /api/taks/<id> will also return submitted, delegated, started and completed timestamp of task in response.

##### The goal of my change is:
This will be helpful to make some decisions for those who are building their applications on the top of cuckoo distributor. 

##### What I have tested about my change is:
I have tested changes manually in cuckoo environment setup and it is working fine.
