### PR TITLE
Add API to download specific file from analysis task

### DIFF
--- a/cuckoo/apps/api.py
+++ b/cuckoo/apps/api.py
@@ -454,6 +454,23 @@ def task_screenshots(task_id=0, screenshot=None):
         response.headers["Content-Type"] = "application/zip"
         return response
 
+@app.route("/tasks/files/<int:task_id>/<file_name>")
+@app.route("/v1/tasks/files/<int:task_id>/<file_name>")
+def task_files(task_id, file_name):
+    folder_path = cwd("storage", "analyses", "%s" % task_id, "files")
+
+    if not os.path.exists(folder_path):
+        return json_error(404, "Task not found")
+
+    file_path = os.path.join(folder_path, file_name)
+    if not os.path.exists(file_path) or os.path.dirname(file_path) != folder_path:
+        return json_error(404, "File not found!")
+
+    # TODO: Add content disposition.
+    response = make_response(open(file_path, "rb").read())
+    response.headers["Content-Type"] = "application/octet-stream"
+    return response
+
 @app.route("/tasks/rereport/<int:task_id>")
 def rereport(task_id):
     task = db.view_task(task_id)

--- a/docs/book/usage/api.rst
+++ b/docs/book/usage/api.rst
@@ -163,6 +163,8 @@ each one. For details click on the resource name.
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_shots`          | Retrieves one or all screenshots associated with a given analysis task ID.                                       |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
+| ``GET`` :ref:`tasks_files`          | Retrieves one of dropped files associated with a given analysis task ID.                                         |
++-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_rereport`       | Re-run reporting for task associated with a given analysis task ID.                                              |
 +-------------------------------------+------------------------------------------------------------------------------------------------------------------+
 | ``GET`` :ref:`tasks_reboot`         | Reboot a given analysis task ID.                                                                                 |
@@ -726,6 +728,30 @@ Returns one or all screenshots associated with the specified task ID.
 
 * ``id`` *(required)* *(int)* - ID of the task to get the report for
 * ``screenshot`` *(optional)* - numerical identifier of a single screenshot (e.g. 0001, 0002)
+
+**Status codes**:
+
+* ``404`` - file or folder not found
+
+.. _tasks_files:
+
+/tasks/files
+------------------
+
+**GET /tasks/files/** *(int: id)* **/** *(str: file_name)*
+
+Retrieves one of dropped files associated with a given analysis task ID.
+
+**Example request**.
+
+.. code-block:: bash
+
+    wget http://localhost:8090/tasks/files/1/0000000000000000_dropped_malware.exe
+
+**Parameters**:
+
+* ``id`` *(required)* *(int)* - ID of the task to get the report for
+* ``file_name`` *(required)* - file name that you want to retrieve
 
 **Status codes**:
 


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

Create new RESTful API to download specific file from the analysis report (`analyses/{task_id}/files/{file_name}`)

##### The goal of my change is:

Download any file instead of all of them (`/tasks/report/<int:task_id>/<report_format>`)

##### What I have tested about my change is:

It works on my own Cuckoo instance