### PR TITLE
creates redundancy for exe.py

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/packages/exe.py
+++ b/cuckoo/data/analyzer/windows/modules/packages/exe.py
@@ -17,6 +17,8 @@ class Exe(Package):
         name, ext = os.path.splitext(path)
         if not ext:
             new_path = name + ".exe"
+            if os.path.exists(new_path):
+                os.remove(new_path)
             os.rename(path, new_path)
             path = new_path
 


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
A simple check to see if the exe exists or not, if it does it removes it. We use cuckoo in a big project and have had issues with is trying to create a file that already exists.

![cuckooIssue](https://user-images.githubusercontent.com/14183473/85890719-88c71980-b7b3-11ea-9cb8-3a2c90e33947.jpg)

All this does is creates a type of redundancy so that if the file exists, it removes it and keeps on going.

##### The goal of my change is:

To make some sort of redundancy in case an issue occurs like the aforementioned

##### What I have tested about my change is:

My own cuckoo sandbox (wrapping it in a try except block would probably work pretty well too just in case)
