### PR TITLE
Update processing.platform.linux.py

### DIFF
--- a/cuckoo/processing/platform/linux.py
+++ b/cuckoo/processing/platform/linux.py
@@ -185,6 +185,8 @@ class StapParser(object):
         arg = argstr.lstrip("{")
         while arg:
             key, _, arg = arg.partition("=")
+            if key == "..." or not arg:
+                continue
             delim = self.get_delim(arg)
             if delim != ", ":
                 delim += ", "


### PR DESCRIPTION
handling parsing exception

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is: exception handling code for parsing linux stap logs 

##### The goal of my change is: bug fix

##### What I have tested about my change is:

cut off the parse-related code with my codes and tested

```python

def get_delim(argstr):
    if is_array(argstr):
        return "]"
    elif is_struct(argstr):
        return "}"
    else:
        return ", "

def parse_arg(argstr):
    if is_array(argstr):
        return parse_array(argstr)
    elif is_struct(argstr):
        return parse_struct(argstr)
    elif is_string(argstr):
        return parse_string(argstr)
    else:
        return argstr

def parse_array(argstr):
    return [parse_arg(a) for a in argstr.lstrip("[").split(", ")]

def parse_struct(argstr):
    # Return as regular array if elements aren't named.
    if "=" not in argstr:
        return parse_array(argstr.lstrip("{"))

    # Return as dict, parse value as array and struct when appropriate.
    parsed = {}
    arg = argstr.lstrip("{")
    while arg:
        key, _, arg = arg.partition("=")
        if key == "...":
            continue
        delim = get_delim(arg)
        if delim != ", ":
            delim += ", "
        val, _, arg = arg.partition(delim)
        parsed[key] = parse_arg(val)

    return parsed

def parse_string(argstr):
    return argstr.strip("\"").decode("string_escape").decode("latin-1")

def is_array(arg):
    return arg.startswith("[") and not arg.startswith("[/*")

def is_struct(arg):
    return arg.startswith("{")

def is_string(arg):
    return arg.startswith("\"") and arg.endswith("\"")


argstr = "{dqb_bhardlimit=3547209367405213234, dqb_bsoftlimit=3204155142452555552, dqb_curspace=7308613718863799666, dqb_ihardlimit=4207599493805798176, dqb_isoftlimit=3779778362997547057, ...}"

parsed = {}
arg = argstr.lstrip("{")
while arg:
    key, _, arg = arg.partition("=")
    if key == "..." or not arg:
        continue
    delim = get_delim(arg)
    if delim != ", ":
        delim += ", "
    val, _, arg = arg.partition(delim)
    parsed[key] = parse_arg(val)

print(parsed)

```
