### PR TITLE
Office window get closed too soon and/or must not be closed automatically in interactive mode.

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/auxiliary/human.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/human.py
@@ -177,7 +177,7 @@ class Human(threading.Thread, Auxiliary):
             self.do_click_buttons = int(self.options["human.click_buttons"])
 
         while self.do_run:
-            if seconds and not seconds % 60:
+            if (self.do_click_buttons or self.do_click_mouse) and  seconds and seconds != 0 and not seconds % 60 :
                 USER32.EnumWindows(EnumWindowsProc(get_office_window), 0)
 
             if self.do_click_mouse:


### PR DESCRIPTION
Closing Office window should be only in automated mode.
Closing Office must not occur during the first run of the loop.

##### What I have added/changed is:
Behavior of human.py auxiliary module
##### The goal of my change is:
Do not close Office window during the first run of the loop in human.py
Do not close Office window in real human interactive mode
##### What I have tested about my change is:
Behavior in "real human" and "automated human" analysis mode

A better improvement would be to use a relative delay matching with XX% of the analysis timeout.

