### PR TITLE
Fix a race condition on multiple tasks getting assigned to the same machine

### DIFF
--- a/cuckoo/core/database.py
+++ b/cuckoo/core/database.py
@@ -851,7 +851,7 @@ class Database(object):
                 raise CuckooOperationalError("No machines match selection criteria.")
 
             # Get the first free machine.
-            machine = machines.filter_by(locked=False).first()
+            machine = machines.filter_by(locked=False).with_for_update().first()
         except SQLAlchemyError as e:
             log.exception("Database error locking machine: {0}".format(e))
             session.close()


### PR DESCRIPTION
This also results in that machine needing rebuilding.

##### What I have added/changed is:
/cuckoo/core/database.py

##### The goal of my change is:
To avoid a race condition on acquiring machines while they are not yet marked as locked.

##### What I have tested about my change is:
Instrumented the code to make the race condition more obvious for testing at runtime.
No specific test case was written for this.