### PR TITLE
Elevate Permissions to avoid Ransomeware Crashes

### DIFF
--- a/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
@@ -23,12 +23,12 @@ class Permissions(Auxiliary):
             # First add a non-inherited permission for Admin Read+Execute
             # icacls <location> /grant:r "BUILTIN\Administrators:(OI)(CI)(RX)" "BUILTIN\\Administrators:(RX)" /t /c /q
             modify_admin_params = ["icacls", location, "/grant:r", "BUILTIN\\Administrators:(OI)(CI)(RX)", "BUILTIN\\Administrators:(RX)", "/t", "/c", "/q"]
-            call(modify_admin_params, startupinfo=self.startupinfo)
+            call(modify_admin_params, startupinfo=self.startupinfo, timeout=15)
 
             # Then remove all inherited permissions so that only SYSTEM has Write access
             # icacls <location> /inheritancelevel:r /t /c /q
             inheritance_params = ["icacls", location, "/inheritancelevel:r", "/t", "/c", "/q"]
-            call(inheritance_params, startupinfo=self.startupinfo)
+            call(inheritance_params, startupinfo=self.startupinfo, timeout=15)
 
     def __init__(self, options={}, analyzer=None):
         Auxiliary.__init__(self, options, analyzer)

--- a/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
@@ -17,12 +17,12 @@ class Permissions(Auxiliary):
         for location in locations:
 
             # First add a non-inherited permission for Admin Read+Execute
-            # icacls <location> /remove:g "BUILTIN\Users" "CREATOR OWNER" /grant:r "BUILTIN\Administrators:(OI)(CI)(RX)" "BUILTIN\\Administrators:(RX)" /t /c /q
+            # icacls <location> /grant:r "BUILTIN\Administrators:(OI)(CI)(RX)" "BUILTIN\\Administrators:(RX)" /t /c /q
             modify_admin_params = ["icacls", location, "/grant:r", "BUILTIN\\Administrators:(OI)(CI)(RX)", "BUILTIN\\Administrators:(RX)", "/t", "/c", "/q"]
             call(modify_admin_params, startupinfo=self.startupinfo)
 
             # Then remove all inherited permissions so that only SYSTEM has Write access
-            # icacls <location> /inheritancelevel:d /t /c /q
+            # icacls <location> /inheritancelevel:r /t /c /q
             inheritance_params = ["icacls", location, "/inheritancelevel:r", "/t", "/c", "/q"]
             call(inheritance_params, startupinfo=self.startupinfo)
 

--- a/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
@@ -1,5 +1,6 @@
 import logging
 from subprocess import call, STARTUPINFO, STARTF_USESHOWWINDOW
+from threading import Thread
 
 from lib.common.abstracts import Auxiliary
 
@@ -23,12 +24,20 @@ class Permissions(Auxiliary):
             # First add a non-inherited permission for Admin Read+Execute
             # icacls <location> /grant:r "BUILTIN\Administrators:(OI)(CI)(RX)" "BUILTIN\\Administrators:(RX)" /t /c /q
             modify_admin_params = ["icacls", location, "/grant:r", "BUILTIN\\Administrators:(OI)(CI)(RX)", "BUILTIN\\Administrators:(RX)", "/t", "/c", "/q"]
-            call(modify_admin_params, startupinfo=self.startupinfo, timeout=15)
+            t1 = Thread(target=call, args=(modify_admin_params,), kwargs={"startupinfo": self.startupinfo})
+            t1.start()
+            t1.join(timeout=15)
+            if t1.is_alive():
+                log.warning("'Modify admin' call was unable to complete in 15 seconds")
 
             # Then remove all inherited permissions so that only SYSTEM has Write access
             # icacls <location> /inheritancelevel:r /t /c /q
             inheritance_params = ["icacls", location, "/inheritancelevel:r", "/t", "/c", "/q"]
-            call(inheritance_params, startupinfo=self.startupinfo, timeout=15)
+            t2 = Thread(target=call, args=(,), kwargs={"pinfo})
+            t2.start()
+            t2.join(timeout=15)
+            if t2.is_alive():
+                log.warning("'Inheritance' call was unable to complete in 15 seconds")
 
     def __init__(self, options={}, analyzer=None):
         Auxiliary.__init__(self, options, analyzer)

--- a/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
@@ -1,0 +1,32 @@
+import logging
+from subprocess import call, STARTUPINFO, STARTF_USESHOWWINDOW
+
+from lib.common.abstracts import Auxiliary
+
+log = logging.getLogger(__name__)
+
+
+class Permissions(Auxiliary):
+    """
+    Change permissions for injected directory and Python interpreter
+    to prevent malware from messing with analysis
+    """
+    def start(self):
+        locations = ["C:\\Python27", self.analyzer.path, "C:\\WindowsAzure"]
+        log.debug("Adjusting permissions for %s", locations)
+        for location in locations:
+
+            # First add a non-inherited permission for Admin Read+Execute
+            # icacls <location> /remove:g "BUILTIN\Users" "CREATOR OWNER" /grant:r "BUILTIN\Administrators:(OI)(CI)(RX)" "BUILTIN\\Administrators:(RX)" /t /c /q
+            modify_admin_params = ["icacls", location, "/grant:r", "BUILTIN\\Administrators:(OI)(CI)(RX)", "BUILTIN\\Administrators:(RX)", "/t", "/c", "/q"]
+            call(modify_admin_params, startupinfo=self.startupinfo)
+
+            # Then remove all inherited permissions so that only SYSTEM has Write access
+            # icacls <location> /inheritancelevel:d /t /c /q
+            inheritance_params = ["icacls", location, "/inheritancelevel:r", "/t", "/c", "/q"]
+            call(inheritance_params, startupinfo=self.startupinfo)
+
+    def __init__(self, options={}, analyzer=None):
+        Auxiliary.__init__(self, options, analyzer)
+        self.startupinfo = STARTUPINFO()
+        self.startupinfo.dwFlags |= STARTF_USESHOWWINDOW

--- a/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
+++ b/cuckoo/data/analyzer/windows/modules/auxiliary/permissions.py
@@ -12,6 +12,10 @@ class Permissions(Auxiliary):
     to prevent malware from messing with analysis
     """
     def start(self):
+        if "permissions" in self.options:
+            if not int(self.options["permissions"]):
+                return
+
         locations = ["C:\\Python27", self.analyzer.path, "C:\\WindowsAzure"]
         log.debug("Adjusting permissions for %s", locations)
         for location in locations:


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Auxiliary module that elevates permissions for certain directories and all files/sub-directories such that only SYSTEM has write access.

##### The goal of my change is:
When dealing with certain ransomware samples, such as `d9c3e675971499e4a2c0677b5ae96cd5582900e7cbfc16a00555ec90335aaebf`, they arbitrarily encrypt all files in all directories located at `C:\\`. This is where the Python interpreter and the injected directory used for analysis are located, and thus they get encrypted and the connection required for analysis breaks. If we elevate the permissions required to write to these directories to exclude Administrators and lower, then this connection prevails and we are able to get the full analysis of this sample.

##### What I have tested about my change is:
General functionality via manual testing.
