### PR TITLE
Add ability to configure if you want proc memdumps from zer0m0n

### DIFF
--- a/cuckoo/data/analyzer/windows/analyzer.py
+++ b/cuckoo/data/analyzer/windows/analyzer.py
@@ -344,7 +344,8 @@ class CommandPipeHandler(object):
             log.warning("Received DUMPMEM command with an incorrect argument.")
             return
 
-        dump_memory(int(data))
+        if self.analyzer.config.options.get("procmemdump"):
+            dump_memory(int(data))
 
     def _handle_dumpreqs(self, data):
         if not data.isdigit():


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Create process memory dumps only if the desire is there (aka it's specified explicitly in `self.analyzer.config.options` as `procmemdump=1`).

##### The goal of my change is:
If you do not explicitly want process memory dumps, you shouldn't have to deal with the additional processing time of uploading .dmp files or the inflated size of the cuckoo tar ball post-analysis. This configuration option is already used here: https://github.com/cuckoosandbox/cuckoo/blob/073c5aab0ff1e4065f665045472309fc4064e354/cuckoo/data/analyzer/windows/analyzer.py#L338, and I believe that the configuration option should be used everywhere `dump_memory` is called.

##### What I have tested about my change is:
Manual testing to ensure correct functionality.
