### PR TITLE
make clear latest Ubuntu LTS is not recommended

### DIFF
--- a/docs/book/installation/host/index.rst
+++ b/docs/book/installation/host/index.rst
@@ -2,9 +2,7 @@
 Preparing the Host
 ==================
 
-To run Cuckoo we suggest a *GNU/Linux* operating system. We'll be using the
-**latest Ubuntu LTS** (16.04 at the time of writing) throughout our
-documentation.
+To run Cuckoo we suggest a *GNU/Linux* operating system. We'll be using Ubuntu 16.04 LTS throughout this documentation and recommend Ubuntu 18.04 LTS (rather than Ubuntu 20.04 LTS) for new installations.
 
 .. toctree::
 


### PR DESCRIPTION
because of issues such as: https://github.com/cuckoosandbox/cuckoo/issues/3134 with current Ubuntu 20.04 TLS.

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

##### The goal of my change is:

##### What I have tested about my change is:
