### PR TITLE
Get specific available machines by label, tag and platform.

### DIFF
--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -162,7 +162,7 @@ class AnalysisManager(threading.Thread):
             # In some cases it's possible that we enter this loop without
             # having any available machines. We should make sure this is not
             # such case, or the analysis task will fail completely.
-            if not machinery.availables(tags=self.task.tags):
+            if not machinery.availables(platform=self.task.platform, tags=self.task.tags):
                 machine_lock.release()
                 time.sleep(1)
                 continue

--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -162,7 +162,7 @@ class AnalysisManager(threading.Thread):
             # In some cases it's possible that we enter this loop without
             # having any available machines. We should make sure this is not
             # such case, or the analysis task will fail completely.
-            if not machinery.availables(platform=self.task.platform, tags=self.task.tags):
+            if not machinery.availables(label=self.task.machine, platform=self.task.platform, tags=self.task.tags):
                 machine_lock.release()
                 time.sleep(1)
                 continue

--- a/cuckoo/core/scheduler.py
+++ b/cuckoo/core/scheduler.py
@@ -162,7 +162,7 @@ class AnalysisManager(threading.Thread):
             # In some cases it's possible that we enter this loop without
             # having any available machines. We should make sure this is not
             # such case, or the analysis task will fail completely.
-            if not machinery.availables():
+            if not machinery.availables(tags=self.task.tags):
                 machine_lock.release()
                 time.sleep(1)
                 continue


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
I submit multiple files with a specific machine names, platforms or tags. I submit more files with these parameters than there are machines that match these characteristics in my Cuckoo system. I want these files that cannot be assigned to a machine right away to wait in the queue. They currently do not in v2.0.7 implementation of `scheduler`, and instead sit in a weird limbo state where they get picked off the queue and then waits for a machine to become available that matches these parameters.

This fix applies to the KVM machinery and label, platform and tags at the moment, by overriding the `availables` method and provides the option to get the count of specific available machines.

I feel like this should be implemented in the `scheduler`, but I can see the argument to have this implemented in `self.db.fetch()` as well. Let me know what you think!

##### The goal of my change is:
Fix the weird limbo state.

##### What I have tested about my change is:
Manual testing for correct functionality.
