### PR TITLE
Correctly parsing URIs

### DIFF
--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -814,13 +814,17 @@ class Pcap2(object):
                 resp_path = os.path.join(self.network_path, resp_sha1)
                 open(resp_path, "wb").write(recv.body or "")
 
+                path = sent.uri
+                host = sent.headers.get("host", dstip)
+                if host in path:
+                    path = path.split(host)[1]
                 results["%s_ex" % protocol].append({
                     "src": srcip, "sport": srcport,
                     "dst": dstip, "dport": dstport,
                     "protocol": protocol,
                     "method": sent.method,
-                    "host": sent.headers.get("host", dstip),
-                    "uri": sent.uri,
+                    "host": host,
+                    "uri": path,
                     "status": int(getattr(recv, "status", 0)),
 
                     # We'll keep these fields here for now.

--- a/cuckoo/processing/network.py
+++ b/cuckoo/processing/network.py
@@ -490,11 +490,16 @@ class Pcap(object):
                 netloc += ":" + str(entry["port"])
 
             entry["data"] = convert_to_printable(tcpdata)
-            url = urlparse.urlunparse(("http", netloc, http.uri,
+            path = http.uri
+            if netloc and netloc in http.uri:
+                path = http.uri.split(netloc)[1]
+            elif entry["host"] and entry["host"] in http.uri:
+                path = http.uri.split(entry["host"])[1]
+            url = urlparse.urlunparse(("http", netloc, path,
                                        None, None, None))
             entry["uri"] = convert_to_printable(url)
             entry["body"] = convert_to_printable(http.body)
-            entry["path"] = convert_to_printable(http.uri)
+            entry["path"] = convert_to_printable(path)
 
             if "user-agent" in http.headers:
                 entry["user-agent"] = \


### PR DESCRIPTION
Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:
Some logic to address edge cases created by certain malware... unfortunately I do not have a public hash to share for recreation.

##### The goal of my change is:
The TCP data captured from network traffic was parsed in the network processing module with the URI containing `<protocol>://<netloc>/<path>`, which then caused issues putting the URL back together [here](https://github.com/cuckoosandbox/cuckoo/blob/073c5aab0ff1e4065f665045472309fc4064e354/cuckoo/processing/network.py#L493). The unparsed URI would then look like `<protocol>://<netloc>/<protocol>://<netloc>/<path>` which is an invalid URI.

The goal of my change is to parse this URI extracted from the pcap correctly before it goes into the `urlunparse` method.

##### What I have tested about my change is:
I tested with the .pcaps generated by the malware that displayed this behaviour, and this change fixes it.

Also this happens in the KVM machinery.